### PR TITLE
Setup dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,23 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: "/eslint-config-base"
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 10
+  - package-ecosystem: npm
+    directory: "/eslint-config-lib"
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 10
+  - package-ecosystem: npm
+    directory: "/eslint-config-react"
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 10
+  - package-ecosystem: npm
+    directory: "/eslint-config-react-ts"
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 10
+  


### PR DESCRIPTION
This enables dependabot for this repo. Since no monorepo helper is setup
(yet), this upgrades each library independantly.