### PR TITLE
Release: latest

### DIFF
--- a/eslint-config-lib/package.json
+++ b/eslint-config-lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inrupt/eslint-config-lib",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Shared eslint config for Javascript at @inrupt",
   "main": "index.js",
   "scripts": {

--- a/eslint-config-lib/package.json
+++ b/eslint-config-lib/package.json
@@ -21,6 +21,6 @@
   },
   "homepage": "https://github.com/inrupt/javascript-style-configs#readme",
   "peerDependencies": {
-    "@inrupt/eslint-config-base": "^0.3.0"
+    "@inrupt/eslint-config-base": "^0.4.0"
   }
 }

--- a/eslint-config-react/package.json
+++ b/eslint-config-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inrupt/eslint-config-react",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Shared eslint config for Javascript at @inrupt",
   "main": "index.js",
   "scripts": {

--- a/eslint-config-react/package.json
+++ b/eslint-config-react/package.json
@@ -21,7 +21,7 @@
   },
   "homepage": "https://github.com/inrupt/javascript-style-configs#readme",
   "peerDependencies": {
-    "@inrupt/eslint-config-base": "^0.3.0",
+    "@inrupt/eslint-config-base": "^0.4.0",
     "eslint": "^7.32.0",
     "eslint-config-airbnb": "^18.1.0",
     "eslint-plugin-jsx-a11y": "^6.2.3",


### PR DESCRIPTION
It seems that due to not using a mono-repo management tool here, that:
- we published `v0.4.0` of `eslint-config-lib` pointing to `eslint-config-base@v0.3.0` instead of `eslint-config-base@v0.4.0`
- we failed to publish a `v0.4.0` of `eslint-config-react` pointing to `eslint-config-base@v0.4.0`

This corrects these mistakes, publishing `v0.4.1` of `eslint-config-lib` and `v0.4.0` of `eslint-config-react` — I have already published these new versions to npm manually.