### PR TITLE
Update peer deps

### DIFF
--- a/eslint-config-base/package.json
+++ b/eslint-config-base/package.json
@@ -24,7 +24,7 @@
     "@typescript-eslint/eslint-plugin": "^5.6.0",
     "@typescript-eslint/parser": "^5.6.0",
     "eslint": "^8.17.0",
-    "eslint-config-airbnb-base": "^15.0.0",
+    "eslint-config-airbnb-base": "^14.2.1",
     "eslint-config-prettier": "^8.3.0",
     "eslint-plugin-header": "^3.1.1",
     "eslint-plugin-import": "^2.20.2",

--- a/eslint-config-base/package.json
+++ b/eslint-config-base/package.json
@@ -23,12 +23,12 @@
   "peerDependencies": {
     "@typescript-eslint/eslint-plugin": "^5.6.0",
     "@typescript-eslint/parser": "^5.6.0",
-    "eslint": "^7.32.0",
-    "eslint-config-airbnb-base": "^14.2.1",
+    "eslint": "^8.17.0",
+    "eslint-config-airbnb-base": "^15.0.0",
     "eslint-config-prettier": "^8.3.0",
     "eslint-plugin-header": "^3.1.1",
     "eslint-plugin-import": "^2.20.2",
-    "eslint-plugin-jest": "^23.13.2",
+    "eslint-plugin-jest": "^26.5.3",
     "eslint-plugin-prettier": "^4.0.0",
     "prettier": "^2.5.1",
     "typescript": "*"

--- a/eslint-config-base/package.json
+++ b/eslint-config-base/package.json
@@ -21,16 +21,16 @@
   },
   "homepage": "https://github.com/inrupt/javascript-style-configs#readme",
   "peerDependencies": {
-    "@typescript-eslint/eslint-plugin": "^5.6.0",
-    "@typescript-eslint/parser": "^5.6.0",
+    "@typescript-eslint/eslint-plugin": "^5.27.1",
+    "@typescript-eslint/parser": "^5.27.1",
     "eslint": "^8.17.0",
     "eslint-config-airbnb-base": "^14.2.1",
-    "eslint-config-prettier": "^8.3.0",
+    "eslint-config-prettier": "^8.5.0",
     "eslint-plugin-header": "^3.1.1",
-    "eslint-plugin-import": "^2.20.2",
+    "eslint-plugin-import": "^2.26.0",
     "eslint-plugin-jest": "^26.5.3",
     "eslint-plugin-prettier": "^4.0.0",
-    "prettier": "^2.5.1",
+    "prettier": "^2.6.2",
     "typescript": "*"
   }
 }

--- a/eslint-config-react/package.json
+++ b/eslint-config-react/package.json
@@ -22,7 +22,7 @@
   "homepage": "https://github.com/inrupt/javascript-style-configs#readme",
   "peerDependencies": {
     "@inrupt/eslint-config-base": "^0.4.0",
-    "eslint": "^7.32.0",
+    "eslint": "^8.17.0",
     "eslint-config-airbnb": "^18.1.0",
     "eslint-plugin-jsx-a11y": "^6.2.3",
     "eslint-plugin-react": "^7.20.0",


### PR DESCRIPTION
The peer dependencies have not been updated for a while and seem to create conflicts in some CI runs:
https://github.com/inrupt/solid-client-access-grants-js/runs/6828224562?check_suite_focus=true#step:4:24

