### PR TITLE
ci: install dependencies before running license-checker

### DIFF
--- a/.github/workflows/reusable-audit.yml
+++ b/.github/workflows/reusable-audit.yml
@@ -20,6 +20,8 @@ jobs:
         with:
           node-version: "16"
           registry-url: "https://registry.npmjs.org"
+      # Install dependencies so license-checker actually checks them:
+      - run: npm ci
       # We check the dependency licenses as part of the audit job, as a
       # misconfigured or inappropriate dependency license is in the same
       # category of issues as an npm audit security failure: we consider 


### PR DESCRIPTION
I noticed that license checker wasn't strictly checking all the licenses, all the time. This fixes that.