### PR TITLE
chore: ensure the package-lock file is updated during releases

### DIFF
--- a/scripts/prepare-release.sh
+++ b/scripts/prepare-release.sh
@@ -19,6 +19,8 @@ if [ $didVersion -eq 0 ]; then
   exit 0
 fi
 
+npm install
+
 # must happen after lerna version as to grab the correct version number,
 # we can use require on json thanks to using commonjs as the type in the root package.json
 nextVersion=$(node -pe 'require("./lerna.json").version')
@@ -26,5 +28,5 @@ packages=$(node -pe 'require("./package.json").workspaces.map((pkg) => `${pkg}/p
 
 git switch -c "release/$nextVersion"
 
-git add lerna.json $packages
+git add lerna.json package-lock.json $packages
 git commit -m "chore(release): publish $nextVersion"


### PR DESCRIPTION
Just noticed this whilst preparing #49, fairly easy to fix.