### PR TITLE
ci: disable @skypack/package-check by default

### DIFF
--- a/.github/workflows/reusable-lint.yml
+++ b/.github/workflows/reusable-lint.yml
@@ -1,6 +1,12 @@
 name: Reusable Lint Workflow
 
-on: workflow_call
+on:
+  workflow_call:
+    inputs:
+      usePackageCheck:
+        required: false
+        default: false
+        type: boolean
 
 jobs:
   lint:
@@ -12,7 +18,8 @@ jobs:
           node-version: "16"
           cache: "npm"
       # Check the package.json is correctly formed
-      - run: npx @skypack/package-check
+      - if: ${{inputs.usePackageCheck}}
+        run: npx @skypack/package-check
       # Install dependencies:
       - run: npm ci --ignore-scripts
       # Run the linting command:


### PR DESCRIPTION
This fixes an issue faced in using this in Laurin's project, and other places where we don't actually want a strict adherence to using `@skypack/package-check`.

This change does mean for libraries that we will need to set `usePackageCheck` to `true` when invoking the `reusable-lint` action, which seems fair.

Alternatively, we can drop the package checker entirely, though it does have some good rules in it: https://docs.skypack.dev/package-authors/package-checks