### PR TITLE
feat(eslint-config): allow shadowing of Jest globals

### DIFF
--- a/eslint-configs/eslint-config-base/index.js
+++ b/eslint-configs/eslint-config-base/index.js
@@ -132,6 +132,23 @@ module.exports = {
       ],
       plugins: ["jest"],
       extends: ["plugin:jest/recommended", "plugin:jest/style"],
+      rules: {
+        "no-shadow": [
+          "warn",
+          {
+            allow: [
+              "describe",
+              "it",
+              "jest",
+              "expect",
+              "beforeEach",
+              "beforeAll",
+              "afterEach",
+              "afterAll",
+            ],
+          },
+        ],
+      },
     },
     {
       files: ["e2e/browser/**/*.playwright.ts"],


### PR DESCRIPTION
We use the `@jest/globals` package, instead of injecting the globals, as such, we need to allow shadowing those methods.