### PR TITLE
chore(release): publish v1.2.0

### DIFF
--- a/eslint-configs/eslint-config-base/package.json
+++ b/eslint-configs/eslint-config-base/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@inrupt/eslint-config-base",
   "description": "Shared eslint config for Javascript at @inrupt",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "publishConfig": {
     "access": "public"
   },

--- a/eslint-configs/eslint-config-lib/package.json
+++ b/eslint-configs/eslint-config-lib/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@inrupt/eslint-config-lib",
   "description": "Shared eslint config for Typescript Libraries used at @inrupt",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "publishConfig": {
     "access": "public"
   },

--- a/eslint-configs/eslint-config-react/package.json
+++ b/eslint-configs/eslint-config-react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@inrupt/eslint-config-react",
   "description": "Shared eslint config for React projects at @inrupt",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "publishConfig": {
     "access": "public"
   },

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
   "useNx": false,
   "useWorkspaces": true,
-  "version": "1.1.0"
+  "version": "1.2.0"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -68,7 +68,7 @@
     },
     "eslint-configs/eslint-config-base": {
       "name": "@inrupt/eslint-config-base",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "license": "MIT",
       "dependencies": {
         "eslint": ">=8.18.0",
@@ -91,7 +91,7 @@
     },
     "eslint-configs/eslint-config-lib": {
       "name": "@inrupt/eslint-config-lib",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "license": "MIT",
       "dependencies": {
         "@inrupt/eslint-config-base": "file:../eslint-config-base",
@@ -102,7 +102,7 @@
     },
     "eslint-configs/eslint-config-react": {
       "name": "@inrupt/eslint-config-react",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "license": "MIT",
       "dependencies": {
         "@babel/eslint-parser": "^7.18.2",


### PR DESCRIPTION
This is a stepping stone towards where we want to be, see the [commits between v1.1.0 and main](https://github.com/inrupt/javascript-style-configs/compare/v1.1.0...main) for details.

This reworks the repository structure and fixes a bug in the `reusable-lint` shared GitHub Actions workflow.