### PR TITLE
Add Uint8Array and crypto to the polyfills 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2646,6 +2646,57 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/@peculiar/asn1-schema": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.3.0.tgz",
+      "integrity": "sha512-DtNLAG4vmDrdSJFPe7rypkcj597chNQL7u+2dBtYo5mh7VW2+im6ke+O0NVr8W1f4re4C3F71LhoMb0Yxqa48Q==",
+      "dependencies": {
+        "asn1js": "^3.0.5",
+        "pvtsutils": "^1.3.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@peculiar/asn1-schema/node_modules/tslib": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+    },
+    "node_modules/@peculiar/json-schema": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/@peculiar/json-schema/-/json-schema-1.1.12.tgz",
+      "integrity": "sha512-coUfuoMeIB7B8/NMekxaDzLhaYmp0HZNPEjYRm9goRou8UZIC3z21s0sL9AWoCw4EG876QyO3kYrc61WNF9B/w==",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@peculiar/json-schema/node_modules/tslib": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+    },
+    "node_modules/@peculiar/webcrypto": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/webcrypto/-/webcrypto-1.4.0.tgz",
+      "integrity": "sha512-U58N44b2m3OuTgpmKgf0LPDOmP3bhwNz01vAnj1mBwxBASRhptWYK+M3zG+HBkDqGQM+bFsoIihTW8MdmPXEqg==",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.1.6",
+        "@peculiar/json-schema": "^1.1.12",
+        "pvtsutils": "^1.3.2",
+        "tslib": "^2.4.0",
+        "webcrypto-core": "^1.7.4"
+      },
+      "engines": {
+        "node": ">=10.12.0"
+      }
+    },
+    "node_modules/@peculiar/webcrypto/node_modules/tslib": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+    },
     "node_modules/@phenomnomnominal/tsquery": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/@phenomnomnominal/tsquery/-/tsquery-4.1.1.tgz",
@@ -3302,6 +3353,24 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
       "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA=="
+    },
+    "node_modules/asn1js": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/asn1js/-/asn1js-3.0.5.tgz",
+      "integrity": "sha512-FVnvrKJwpt9LP2lAMl8qZswRNm3T4q9CON+bxldk2iwk3FFpuwhx2FfinyitizWHsVYyaY+y5JzDR0rCMV5yTQ==",
+      "dependencies": {
+        "pvtsutils": "^1.3.2",
+        "pvutils": "^1.1.3",
+        "tslib": "^2.4.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/asn1js/node_modules/tslib": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
     },
     "node_modules/ast-types-flow": {
       "version": "0.0.7",
@@ -9255,6 +9324,27 @@
         "node": ">=6"
       }
     },
+    "node_modules/pvtsutils": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/pvtsutils/-/pvtsutils-1.3.2.tgz",
+      "integrity": "sha512-+Ipe2iNUyrZz+8K/2IOo+kKikdtfhRKzNpQbruF2URmqPtoqAs8g3xS7TJvFF2GcPXjh7DkqMnpVveRFq4PgEQ==",
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/pvtsutils/node_modules/tslib": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+    },
+    "node_modules/pvutils": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/pvutils/-/pvutils-1.1.3.tgz",
+      "integrity": "sha512-pMpnA0qRdFp32b1sJl1wOJNxZLQ2cbQx+k6tjNtZ8CpvVhNqEPRgivZ2WOUev2YMajecdH7ctUPDvEe87nariQ==",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/q": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
@@ -10569,6 +10659,23 @@
         "node": ">= 8"
       }
     },
+    "node_modules/webcrypto-core": {
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/webcrypto-core/-/webcrypto-core-1.7.5.tgz",
+      "integrity": "sha512-gaExY2/3EHQlRNNNVSrbG2Cg94Rutl7fAaKILS1w8ZDhGxdFOaw6EbCfHIxPy9vt/xwp5o0VQAx9aySPF6hU1A==",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.1.6",
+        "@peculiar/json-schema": "^1.1.12",
+        "asn1js": "^3.0.1",
+        "pvtsutils": "^1.3.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/webcrypto-core/node_modules/tslib": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+    },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
@@ -10867,6 +10974,7 @@
       "version": "1.3.0",
       "license": "MIT",
       "dependencies": {
+        "@peculiar/webcrypto": "^1.4.0",
         "@web-std/blob": "^3.0.4",
         "@web-std/file": "^3.0.2"
       },
@@ -11331,6 +11439,7 @@
     "@inrupt/jest-jsdom-polyfills": {
       "version": "file:packages/jest-jsdom-polyfills",
       "requires": {
+        "@peculiar/webcrypto": "*",
         "@types/node": "^18.8.5",
         "@web-std/blob": "^3.0.4",
         "@web-std/file": "^3.0.2"
@@ -12788,6 +12897,57 @@
         "node-gyp-build": "^4.3.0"
       }
     },
+    "@peculiar/asn1-schema": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.3.0.tgz",
+      "integrity": "sha512-DtNLAG4vmDrdSJFPe7rypkcj597chNQL7u+2dBtYo5mh7VW2+im6ke+O0NVr8W1f4re4C3F71LhoMb0Yxqa48Q==",
+      "requires": {
+        "asn1js": "^3.0.5",
+        "pvtsutils": "^1.3.2",
+        "tslib": "^2.4.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+        }
+      }
+    },
+    "@peculiar/json-schema": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/@peculiar/json-schema/-/json-schema-1.1.12.tgz",
+      "integrity": "sha512-coUfuoMeIB7B8/NMekxaDzLhaYmp0HZNPEjYRm9goRou8UZIC3z21s0sL9AWoCw4EG876QyO3kYrc61WNF9B/w==",
+      "requires": {
+        "tslib": "^2.0.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+        }
+      }
+    },
+    "@peculiar/webcrypto": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/webcrypto/-/webcrypto-1.4.0.tgz",
+      "integrity": "sha512-U58N44b2m3OuTgpmKgf0LPDOmP3bhwNz01vAnj1mBwxBASRhptWYK+M3zG+HBkDqGQM+bFsoIihTW8MdmPXEqg==",
+      "requires": {
+        "@peculiar/asn1-schema": "^2.1.6",
+        "@peculiar/json-schema": "^1.1.12",
+        "pvtsutils": "^1.3.2",
+        "tslib": "^2.4.0",
+        "webcrypto-core": "^1.7.4"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+        }
+      }
+    },
     "@phenomnomnominal/tsquery": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/@phenomnomnominal/tsquery/-/tsquery-4.1.1.tgz",
@@ -13240,6 +13400,23 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
       "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA=="
+    },
+    "asn1js": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/asn1js/-/asn1js-3.0.5.tgz",
+      "integrity": "sha512-FVnvrKJwpt9LP2lAMl8qZswRNm3T4q9CON+bxldk2iwk3FFpuwhx2FfinyitizWHsVYyaY+y5JzDR0rCMV5yTQ==",
+      "requires": {
+        "pvtsutils": "^1.3.2",
+        "pvutils": "^1.1.3",
+        "tslib": "^2.4.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+        }
+      }
     },
     "ast-types-flow": {
       "version": "0.0.7"
@@ -17319,6 +17496,26 @@
     "punycode": {
       "version": "2.1.1"
     },
+    "pvtsutils": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/pvtsutils/-/pvtsutils-1.3.2.tgz",
+      "integrity": "sha512-+Ipe2iNUyrZz+8K/2IOo+kKikdtfhRKzNpQbruF2URmqPtoqAs8g3xS7TJvFF2GcPXjh7DkqMnpVveRFq4PgEQ==",
+      "requires": {
+        "tslib": "^2.4.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+        }
+      }
+    },
+    "pvutils": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/pvutils/-/pvutils-1.1.3.tgz",
+      "integrity": "sha512-pMpnA0qRdFp32b1sJl1wOJNxZLQ2cbQx+k6tjNtZ8CpvVhNqEPRgivZ2WOUev2YMajecdH7ctUPDvEe87nariQ=="
+    },
     "q": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
@@ -18222,6 +18419,25 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.1.tgz",
       "integrity": "sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q=="
+    },
+    "webcrypto-core": {
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/webcrypto-core/-/webcrypto-core-1.7.5.tgz",
+      "integrity": "sha512-gaExY2/3EHQlRNNNVSrbG2Cg94Rutl7fAaKILS1w8ZDhGxdFOaw6EbCfHIxPy9vt/xwp5o0VQAx9aySPF6hU1A==",
+      "requires": {
+        "@peculiar/asn1-schema": "^2.1.6",
+        "@peculiar/json-schema": "^1.1.12",
+        "asn1js": "^3.0.1",
+        "pvtsutils": "^1.3.2",
+        "tslib": "^2.4.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+        }
+      }
     },
     "webidl-conversions": {
       "version": "3.0.1",

--- a/packages/jest-jsdom-polyfills/index.js
+++ b/packages/jest-jsdom-polyfills/index.js
@@ -41,11 +41,12 @@ if (
 }
 
 if (
+  typeof globalThis.crypto !== "undefined" &&
+  // jsdom doesn't implement the subtle Web Crypto API
   typeof globalThis.crypto.subtle === "undefined"
 ) {
   // Requires OPENSSL_CONF=/dev/null (see https://github.com/nodejs/node/discussions/43184) 
   const { Crypto, CryptoKey } = require("@peculiar/webcrypto");
-  // jsdom doesn't implement the Web Crypto API
   Object.assign(globalThis.crypto, new Crypto());
   globalThis.CryptoKey = CryptoKey;
 }

--- a/packages/jest-jsdom-polyfills/index.js
+++ b/packages/jest-jsdom-polyfills/index.js
@@ -36,17 +36,17 @@ if (
   // TextEncoder references a Uint8Array constructor different than the global
   // one used by users in tests. The following enforces the same constructor to
   // be referenced by both.
+  // FIXME: currently this doesn't work, and must be set in a custom environment.
   globalThis.Uint8Array = Uint8Array;
 }
 
 if (
-  typeof globalThis.crypto.subtle === undefined
+  typeof globalThis.crypto.subtle === "undefined"
 ) {
-  // Requires OPENSSL_CONF=/dev/null (see https://github.com/nodejs/node/discussions/43184?sort=new) 
+  // Requires OPENSSL_CONF=/dev/null (see https://github.com/nodejs/node/discussions/43184) 
   const { Crypto, CryptoKey } = require("@peculiar/webcrypto");
   // jsdom doesn't implement the Web Crypto API
-  // For some reason,  this.global.crypto = new Crypto() leaves .subtle undefined
-  globalThis.crypto.subtle = (new Crypto()).subtle;
+  Object.assign(globalThis.crypto, new Crypto());
   globalThis.CryptoKey = CryptoKey;
 }
 

--- a/packages/jest-jsdom-polyfills/index.js
+++ b/packages/jest-jsdom-polyfills/index.js
@@ -33,6 +33,21 @@ if (
   // @ts-ignore TextDecoder from util doesn't necessarily conform to that from
   // the Web APIs, but it's good enough:
   globalThis.TextDecoder = utils.TextDecoder;
+  // TextEncoder references a Uint8Array constructor different than the global
+  // one used by users in tests. The following enforces the same constructor to
+  // be referenced by both.
+  globalThis.Uint8Array = Uint8Array;
+}
+
+if (
+  typeof globalThis.crypto.subtle === undefined
+) {
+  // Requires OPENSSL_CONF=/dev/null (see https://github.com/nodejs/node/discussions/43184?sort=new) 
+  const { Crypto, CryptoKey } = require("@peculiar/webcrypto");
+  // jsdom doesn't implement the Web Crypto API
+  // For some reason,  this.global.crypto = new Crypto() leaves .subtle undefined
+  globalThis.crypto.subtle = (new Crypto()).subtle;
+  globalThis.CryptoKey = CryptoKey;
 }
 
 // Node.js doesn't support Blob or File, so we're polyfilling those with

--- a/packages/jest-jsdom-polyfills/package.json
+++ b/packages/jest-jsdom-polyfills/package.json
@@ -25,6 +25,7 @@
   },
   "homepage": "https://github.com/inrupt/javascript-style-configs#readme",
   "dependencies": {
+    "@peculiar/webcrypto": "^1.4.0",
     "@web-std/blob": "^3.0.4",
     "@web-std/file": "^3.0.2"
   },


### PR DESCRIPTION
JSDom doesn't implement the Crypto APIs that are needed by jose. The TextEncoder util also depends on a different constructor for Uint8Array than the jsdom one, resulting in errors at runtime. However, the current fix doesn't work, and a custom target environment is still required (included here for reference).