### PR TITLE
chore: rename repo to typescript-sdk-tools

### DIFF
--- a/eslint-configs/eslint-config-base/package.json
+++ b/eslint-configs/eslint-config-base/package.json
@@ -8,7 +8,7 @@
   "main": "index.js",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/inrupt/javascript-style-configs.git"
+    "url": "git+https://github.com/inrupt/typescript-sdk-tools.git"
   },
   "keywords": [
     "eslint",
@@ -17,9 +17,9 @@
   "author": "Inrupt <engineering@inrupt.com>",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/inrupt/javascript-style-configs/issues"
+    "url": "https://github.com/inrupt/typescript-sdk-tools/issues"
   },
-  "homepage": "https://github.com/inrupt/javascript-style-configs#readme",
+  "homepage": "https://github.com/inrupt/typescript-sdk-tools/tree/main/eslint-configs/eslint-config-base#readme",
   "dependencies": {
     "eslint": ">=8.18.0",
     "eslint-config-airbnb-base": "^15.0.0",

--- a/eslint-configs/eslint-config-lib/package.json
+++ b/eslint-configs/eslint-config-lib/package.json
@@ -8,7 +8,7 @@
   "main": "index.js",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/inrupt/javascript-style-configs.git"
+    "url": "git+https://github.com/inrupt/typescript-sdk-tools.git"
   },
   "keywords": [
     "eslint",
@@ -17,9 +17,9 @@
   "author": "Inrupt <engineering@inrupt.com>",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/inrupt/javascript-style-configs/issues"
+    "url": "https://github.com/inrupt/typescript-sdk-tools/issues"
   },
-  "homepage": "https://github.com/inrupt/javascript-style-configs#readme",
+  "homepage": "https://github.com/inrupt/typescript-sdk-tools/tree/main/eslint-configs/eslint-config-lib#readme",
   "dependencies": {
     "@inrupt/eslint-config-base": "file:../eslint-config-base",
     "@typescript-eslint/eslint-plugin": "^5.29.0",

--- a/eslint-configs/eslint-config-react/package.json
+++ b/eslint-configs/eslint-config-react/package.json
@@ -8,7 +8,7 @@
   "main": "index.js",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/inrupt/javascript-style-configs.git"
+    "url": "git+https://github.com/inrupt/typescript-sdk-tools.git"
   },
   "keywords": [
     "eslint",
@@ -18,9 +18,9 @@
   "author": "Inrupt <engineering@inrupt.com>",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/inrupt/javascript-style-configs/issues"
+    "url": "https://github.com/inrupt/typescript-sdk-tools/issues"
   },
-  "homepage": "https://github.com/inrupt/javascript-style-configs#readme",
+  "homepage": "https://github.com/inrupt/typescript-sdk-tools/tree/main/eslint-configs/eslint-config-react#readme",
   "dependencies": {
     "@babel/eslint-parser": "^7.18.2",
     "@inrupt/eslint-config-base": "file:../eslint-config-base",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "javascript-style-configs",
+  "name": "typescript-sdk-tools",
   "version": "0.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "javascript-style-configs",
+      "name": "typescript-sdk-tools",
       "version": "0.0.0",
       "license": "MIT",
       "workspaces": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "javascript-style-configs",
-  "description": "Meta-package for eslint configurations",
+  "name": "typescript-sdk-tools",
+  "description": "Meta-package for tools used whilst developing the Typescript SDK",
   "version": "0.0.0",
   "private": true,
   "type": "commonjs",
@@ -14,14 +14,14 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/inrupt/javascript-style-configs.git"
+    "url": "git+https://github.com/inrupt/typescript-sdk-tools.git"
   },
   "author": "Inrupt <engineering@inrupt.com>",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/inrupt/javascript-style-configs/issues"
+    "url": "https://github.com/inrupt/typescript-sdk-tools/issues"
   },
-  "homepage": "https://github.com/inrupt/javascript-style-configs#readme",
+  "homepage": "https://github.com/inrupt/typescript-sdk-tools#readme",
   "dependencies": {
     "lerna": "^5.1.8"
   }

--- a/packages/jest-jsdom-polyfills/package.json
+++ b/packages/jest-jsdom-polyfills/package.json
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/inrupt/javascript-style-configs.git"
+    "url": "git+https://github.com/inrupt/typescript-sdk-tools.git"
   },
   "keywords": [
     "inrupt",
@@ -21,9 +21,9 @@
   "author": "Inrupt <engineering@inrupt.com>",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/inrupt/javascript-style-configs/issues"
+    "url": "https://github.com/inrupt/typescript-sdk-tools/issues"
   },
-  "homepage": "https://github.com/inrupt/javascript-style-configs#readme",
+  "homepage": "https://github.com/inrupt/typescript-sdk-tools#readme",
   "dependencies": {
     "@peculiar/webcrypto": "^1.4.0",
     "@web-std/blob": "^3.0.4",


### PR DESCRIPTION
This just changes the package.json's to point to the right things.