### PR TITLE
Add optional build step for packages that need build pre-release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,7 @@ jobs:
           cache: npm
           registry-url: "https://registry.npmjs.org"
       - run: npm ci --workspaces
+      - run: npm run build --if-present --workspaces
       - run: npm run release
         env:
           NODE_AUTH_TOKEN: ${{ secrets.INRUPT_NPM_TOKEN }}

--- a/packages/internal-test-env/rollup.config.mjs
+++ b/packages/internal-test-env/rollup.config.mjs
@@ -32,6 +32,13 @@ const rollupDefaultConfig = { external, plugins };
 export default [
   {
     ...rollupDefaultConfig,
+    external: [
+      "dotenv",
+      "path",
+      "deepmerge-json",
+      "@inrupt/solid-client-authn-node",
+      "@inrupt/solid-client",
+    ],
     input: "index.ts",
     output: [
       {
@@ -47,6 +54,13 @@ export default [
   },
   {
     ...rollupDefaultConfig,
+    external: [
+      "dotenv",
+      "path",
+      "deepmerge-json",
+      "@inrupt/solid-client-authn-node",
+      "@inrupt/solid-client",
+    ],
     input: ["index.ts"],
     output: {
       dir: "dist",


### PR DESCRIPTION
Adding in needed extra step to build packages that need to build pre-release.

Was testing with `npm link` locally with the 1.4.1 build locally, however after publish realized tarball was missing built exports. 