### PR TITLE
chore: prevent audits from running on devDependencies

### DIFF
--- a/.github/workflows/reusable-audit.yml
+++ b/.github/workflows/reusable-audit.yml
@@ -24,7 +24,7 @@ jobs:
       # bad licenses a vulnerability.
       - run: npx license-checker --production --failOn "AGPL-1.0-only; AGPL-1.0-or-later; AGPL-3.0-only; AGPL-3.0-or-later; Beerware; CC-BY-NC-1.0; CC-BY-NC-2.0; CC-BY-NC-2.5; CC-BY-NC-3.0; CC-BY-NC-4.0; CC-BY-NC-ND-1.0; CC-BY-NC-ND-2.0; CC-BY-NC-ND-2.5; CC-BY-NC-ND-3.0; CC-BY-NC-ND-4.0; CC-BY-NC-SA-1.0; CC-BY-NC-SA-2.0; CC-BY-NC-SA-2.5; CC-BY-NC-SA-3.0; CC-BY-NC-SA-4.0; CPAL-1.0; EUPL-1.0; EUPL-1.1; EUPL-1.1;  GPL-1.0-only; GPL-1.0-or-later; GPL-2.0-only;  GPL-2.0-or-later; GPL-3.0; GPL-3.0-only; GPL-3.0-or-later; SISSL;  SISSL-1.2; WTFPL"
       # Run the audit and capture the results
-      - run: npm audit --audit-level=moderate
+      - run: npm audit --audit-level=moderate --omit=dev
       # Publishes a notification to a slack channel:
       - name: Send a notification that the audit has failed
         if: failure() && github.event_name == 'schedule'


### PR DESCRIPTION
This is required in order to get this action running on @inrupt/solid-ui-react, essentially that repo will _never_ pass audit of all the dependencies as it builds off storybook which is always horrendously out of date.

What we care about most with audits is that the dependencies we ship with our SDKs to customers do not contain vulnerabilities. Tangentially, our team should be looking at any audit warnings when installing in development and taking action to rectify issues.