### PR TITLE
chore(release): publish 1.4.3

### DIFF
--- a/eslint-configs/eslint-config-base/package.json
+++ b/eslint-configs/eslint-config-base/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@inrupt/eslint-config-base",
   "description": "Shared eslint config for Javascript at @inrupt",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "publishConfig": {
     "access": "public"
   },

--- a/eslint-configs/eslint-config-lib/package.json
+++ b/eslint-configs/eslint-config-lib/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@inrupt/eslint-config-lib",
   "description": "Shared eslint config for Typescript Libraries used at @inrupt",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "publishConfig": {
     "access": "public"
   },

--- a/eslint-configs/eslint-config-react/package.json
+++ b/eslint-configs/eslint-config-react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@inrupt/eslint-config-react",
   "description": "Shared eslint config for React projects at @inrupt",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "publishConfig": {
     "access": "public"
   },

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
   "useNx": false,
   "useWorkspaces": true,
-  "version": "1.4.2"
+  "version": "1.4.3"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -68,7 +68,7 @@
     },
     "eslint-configs/eslint-config-base": {
       "name": "@inrupt/eslint-config-base",
-      "version": "1.4.2",
+      "version": "1.4.3",
       "license": "MIT",
       "dependencies": {
         "eslint": ">=8.18.0",
@@ -128,7 +128,7 @@
     },
     "eslint-configs/eslint-config-lib": {
       "name": "@inrupt/eslint-config-lib",
-      "version": "1.4.2",
+      "version": "1.4.3",
       "license": "MIT",
       "dependencies": {
         "@inrupt/eslint-config-base": "file:../eslint-config-base",
@@ -139,7 +139,7 @@
     },
     "eslint-configs/eslint-config-react": {
       "name": "@inrupt/eslint-config-react",
-      "version": "1.4.2",
+      "version": "1.4.3",
       "license": "MIT",
       "dependencies": {
         "@babel/eslint-parser": "^7.18.2",
@@ -11636,7 +11636,7 @@
     },
     "packages/internal-test-env": {
       "name": "@inrupt/internal-test-env",
-      "version": "1.4.2",
+      "version": "1.4.3",
       "license": "MIT",
       "dependencies": {
         "@inrupt/solid-client": "^1.23.3",
@@ -11660,7 +11660,7 @@
     },
     "packages/jest-jsdom-polyfills": {
       "name": "@inrupt/jest-jsdom-polyfills",
-      "version": "1.4.2",
+      "version": "1.4.3",
       "license": "MIT",
       "dependencies": {
         "@peculiar/webcrypto": "^1.4.0",

--- a/packages/internal-test-env/package.json
+++ b/packages/internal-test-env/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inrupt/internal-test-env",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "description": "This package provides various test environment utilities needed for jest when using the Inrupt SDKs",
   "main": "dist/index.js",
   "module": "dist/index.es.js",

--- a/packages/jest-jsdom-polyfills/package.json
+++ b/packages/jest-jsdom-polyfills/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inrupt/jest-jsdom-polyfills",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "description": "This package provides various polyfills needed on jest/jsdom when using the Inrupt SDKs",
   "main": "index.js",
   "publishConfig": {


### PR DESCRIPTION
This release only contains changes to the way the `reusable-audit` action works, and some minor dependency updates.