### PR TITLE
Remove test for cognito domain

### DIFF
--- a/packages/internal-playwright-helpers/src/pages/cognito.ts
+++ b/packages/internal-playwright-helpers/src/pages/cognito.ts
@@ -35,12 +35,6 @@ export class CognitoPage {
   }
 
   async login(username: string, password: string) {
-    const pageUrl = new URL(this.page.url());
-    if(!pageUrl.hostname.includes(CognitoPage.COGNITO_DOMAIN)) {
-      throw new Error(
-        `Expected domain ${CognitoPage.COGNITO_DOMAIN} for login, found ${pageUrl.href}`
-      );
-    }
     await this.page.fill(".visible-lg [type=text]", username);
     await this.page.fill(".visible-lg [type=password]", password);
     await Promise.all([

--- a/packages/internal-playwright-helpers/src/pages/cognito.ts
+++ b/packages/internal-playwright-helpers/src/pages/cognito.ts
@@ -28,8 +28,6 @@ import { Page } from "@playwright/test";
 export class CognitoPage {
   page: Page;
 
-  static COGNITO_DOMAIN = "amazoncognito.com ";
-
   constructor(page: Page) {
     this.page = page;
   }


### PR DESCRIPTION
Actually the cognito login is served on the app's domain, so that check fails on PodSpaces for instance