### PR TITLE
Move notifications and VC configs to shared env

### DIFF
--- a/packages/internal-test-env/index.ts
+++ b/packages/internal-test-env/index.ts
@@ -45,9 +45,6 @@ export type AvailableEnvironment = typeof availableEnvironment extends Array<
   : never;
 
 export interface TestingEnvironmentNode extends TestingEnvironmentBase {
-  notificationGateway?: string;
-  notificationProtocol?: string;
-  vcProvider?: string;
   clientCredentials: {
     owner: {
       id: string;
@@ -74,6 +71,9 @@ export interface TestingEnvironmentBase {
   environment: AvailableEnvironment;
   idp: string;
   features: FeatureFlags | undefined;
+  notificationGateway?: string;
+  notificationProtocol?: string;
+  vcProvider?: string;
 }
 
 type FeatureFlags = {


### PR DESCRIPTION
They were previously only in the Node test environment, which prevents from using them in the browser tests.