### PR TITLE
Refactor environment variables validation

### DIFF
--- a/packages/internal-playwright-helpers/src/fixtures.ts
+++ b/packages/internal-playwright-helpers/src/fixtures.ts
@@ -15,7 +15,7 @@ export const test = base.extend<AuthFixture>({
   auth: async ({ page }, use) => {
     const { idp, clientCredentials } = getBrowserTestingEnvironment({
       clientCredentials: {
-        owner: { login: "", password: "" },
+        owner: { login: true, password: true },
       },
     });
     const auth = new AuthFlow(

--- a/packages/internal-test-env/index.ts
+++ b/packages/internal-test-env/index.ts
@@ -212,9 +212,9 @@ export interface NodeVariables extends LibraryVariables {
   };
 }
 
-function validateLibVars(vars: LibraryVariables): object {
+function validateLibVars(varsToValidate: LibraryVariables): object {
   // Notifications-related environment variables.
-  if (vars.notificationGateway) {
+  if (varsToValidate.notificationGateway) {
     if (typeof process.env.E2E_TEST_NOTIFICATION_GATEWAY !== "string") {
       throw new Error(
         "Missing the E2E_TEST_NOTIFICATION_GATEWAY environment variable"
@@ -227,7 +227,7 @@ function validateLibVars(vars: LibraryVariables): object {
     }
   }
 
-  if (vars.notificationProtocol) {
+  if (varsToValidate.notificationProtocol) {
     if (typeof process.env.E2E_TEST_NOTIFICATION_PROTOCOL !== "string"
     ) {
       throw new Error(
@@ -242,7 +242,7 @@ function validateLibVars(vars: LibraryVariables): object {
   }
     
   // VC-related environment variables.
-  if (vars.vcProvider) {
+  if (varsToValidate.vcProvider) {
     if (typeof process.env.E2E_TEST_VC_PROVIDER !== "string"
     ) {
       throw new Error(
@@ -258,7 +258,7 @@ function validateLibVars(vars: LibraryVariables): object {
     
   // Resource owner static credentials.
   if (
-    vars.clientCredentials?.owner?.id &&
+    varsToValidate.clientCredentials?.owner?.id &&
     typeof process.env.E2E_TEST_OWNER_CLIENT_ID !== "string"
   ) {
     throw new Error(
@@ -266,7 +266,7 @@ function validateLibVars(vars: LibraryVariables): object {
     );
   }
   if (
-    vars.clientCredentials?.owner?.secret &&
+    varsToValidate.clientCredentials?.owner?.secret &&
     typeof process.env.E2E_TEST_OWNER_CLIENT_SECRET !== "string"
   ) {
     throw new Error(
@@ -275,7 +275,7 @@ function validateLibVars(vars: LibraryVariables): object {
   }
   // Resource requestor static credentials.
   if (
-    vars.clientCredentials?.requestor?.id &&
+    varsToValidate.clientCredentials?.requestor?.id &&
     typeof process.env.E2E_TEST_REQUESTOR_CLIENT_ID !== "string"
   ) {
     throw new Error(
@@ -283,7 +283,7 @@ function validateLibVars(vars: LibraryVariables): object {
     );
   }
   if (
-    vars.clientCredentials?.requestor?.secret &&
+    varsToValidate.clientCredentials?.requestor?.secret &&
     typeof process.env.E2E_TEST_REQUESTOR_CLIENT_SECRET !== "string"
   ) {
     throw new Error(
@@ -292,13 +292,13 @@ function validateLibVars(vars: LibraryVariables): object {
   }
   // Resource owner username/password.
   if (
-    vars.clientCredentials?.owner?.login &&
+    varsToValidate.clientCredentials?.owner?.login &&
     typeof process.env.E2E_TEST_USER !== "string"
   ) {
     throw new Error("The environment variable E2E_TEST_USER is undefined.");
   }
   if (
-    vars.clientCredentials?.owner?.password &&
+    varsToValidate.clientCredentials?.owner?.password &&
     typeof process.env.E2E_TEST_PASSWORD !== "string"
   ) {
     throw new Error("The environment variable E2E_TEST_PASSWORD is undefined.");

--- a/packages/internal-test-env/index.ts
+++ b/packages/internal-test-env/index.ts
@@ -257,7 +257,8 @@ function validateLibVars(varsToValidate: LibraryVariables): object {
   // Resource owner static credentials.
   if (
     varsToValidate.clientCredentials?.owner?.id &&
-    typeof process.env.E2E_TEST_OWNER_CLIENT_ID !== "string"
+    typeof process.env.E2E_TEST_OWNER_CLIENT_ID !== "string" &&
+    process.env.E2E_TEST_OWNER_CLIENT_ID !== ""
   ) {
     throw new Error(
       "Missing the E2E_TEST_OWNER_CLIENT_ID environment variable"
@@ -265,7 +266,8 @@ function validateLibVars(varsToValidate: LibraryVariables): object {
   }
   if (
     varsToValidate.clientCredentials?.owner?.secret &&
-    typeof process.env.E2E_TEST_OWNER_CLIENT_SECRET !== "string"
+    typeof process.env.E2E_TEST_OWNER_CLIENT_SECRET !== "string" &&
+    process.env.E2E_TEST_OWNER_CLIENT_SECRET !== ""
   ) {
     throw new Error(
       "Missing the E2E_TEST_OWNER_CLIENT_SECRET environment variable"
@@ -274,7 +276,8 @@ function validateLibVars(varsToValidate: LibraryVariables): object {
   // Resource requestor static credentials.
   if (
     varsToValidate.clientCredentials?.requestor?.id &&
-    typeof process.env.E2E_TEST_REQUESTOR_CLIENT_ID !== "string"
+    typeof process.env.E2E_TEST_REQUESTOR_CLIENT_ID !== "string" &&
+    process.env.E2E_TEST_REQUESTOR_CLIENT_ID !== ""
   ) {
     throw new Error(
       "Missing the E2E_TEST_REQUESTOR_CLIENT_ID environment variable"
@@ -282,7 +285,8 @@ function validateLibVars(varsToValidate: LibraryVariables): object {
   }
   if (
     varsToValidate.clientCredentials?.requestor?.secret &&
-    typeof process.env.E2E_TEST_REQUESTOR_CLIENT_SECRET !== "string"
+    typeof process.env.E2E_TEST_REQUESTOR_CLIENT_SECRET !== "string" &&
+    process.env.E2E_TEST_REQUESTOR_CLIENT_SECRET !== ""
   ) {
     throw new Error(
       "Missing the E2E_TEST_REQUESTOR_CLIENT_SECRET environment variable"
@@ -291,13 +295,15 @@ function validateLibVars(varsToValidate: LibraryVariables): object {
   // Resource owner username/password.
   if (
     varsToValidate.clientCredentials?.owner?.login &&
-    typeof process.env.E2E_TEST_USER !== "string"
+    typeof process.env.E2E_TEST_USER !== "string" &&
+    process.env.E2E_TEST_USER !== ""
   ) {
     throw new Error("The environment variable E2E_TEST_USER is undefined.");
   }
   if (
     varsToValidate.clientCredentials?.owner?.password &&
-    typeof process.env.E2E_TEST_PASSWORD !== "string"
+    typeof process.env.E2E_TEST_PASSWORD !== "string" &&
+    process.env.E2E_TEST_PASSWORD !== ""
   ) {
     throw new Error("The environment variable E2E_TEST_PASSWORD is undefined.");
   }

--- a/packages/internal-test-env/index.ts
+++ b/packages/internal-test-env/index.ts
@@ -30,6 +30,7 @@ import {
   getSourceIri,
   saveSolidDatasetInContainer,
 } from "@inrupt/solid-client";
+import { isValidUrl } from "./utils";
 
 export const availableEnvironment = [
   "ESS Dev-Next" as const,
@@ -213,31 +214,48 @@ export interface NodeVariables extends LibraryVariables {
 
 function validateLibVars(vars: LibraryVariables): object {
   // Notifications-related environment variables.
-  if (
-    vars.notificationGateway &&
-    typeof process.env.E2E_TEST_NOTIFICATION_GATEWAY !== "string"
-  ) {
-    throw new Error(
-      "Missing the E2E_TEST_NOTIFICATION_GATEWAY environment variable"
-    );
+  if (vars.notificationGateway) {
+    if (typeof process.env.E2E_TEST_NOTIFICATION_GATEWAY !== "string") {
+      throw new Error(
+        "Missing the E2E_TEST_NOTIFICATION_GATEWAY environment variable"
+      );
+    } else if (!isValidUrl(process.env.E2E_TEST_NOTIFICATION_GATEWAY)) {
+      throw new Error(
+        `Expected E2E_TEST_NOTIFICATION_GATEWAY environment variable to be an IRI, found: ${
+          process.env.E2E_TEST_NOTIFICATION_GATEWAY}`
+      );
+    }
   }
-  if (
-    vars.notificationProtocol &&
-    typeof process.env.E2E_TEST_NOTIFICATION_PROTOCOL !== "string"
-  ) {
-    throw new Error(
-      "Missing the E2E_TEST_NOTIFICATION_PROTOCOL environment variable"
-    );
+
+  if (vars.notificationProtocol) {
+    if (typeof process.env.E2E_TEST_NOTIFICATION_PROTOCOL !== "string"
+    ) {
+      throw new Error(
+        "Missing the E2E_TEST_NOTIFICATION_PROTOCOL environment variable"
+      );
+    } else if (!isValidUrl(process.env.E2E_TEST_NOTIFICATION_PROTOCOL)) {
+      throw new Error(
+        `Expected E2E_TEST_NOTIFICATION_PROTOCOL environment variable to be an IRI, found: ${
+          process.env.E2E_TEST_NOTIFICATION_PROTOCOL}`
+      );
+    }
   }
+    
   // VC-related environment variables.
-  if (
-    vars.vcProvider &&
-    typeof process.env.E2E_TEST_VC_PROVIDER !== "string"
-  ) {
-    throw new Error(
-      "Missing the E2E_TEST_NOTIFICATION_PROTOCOL environment variable"
-    );
+  if (vars.vcProvider) {
+    if (typeof process.env.E2E_TEST_VC_PROVIDER !== "string"
+    ) {
+      throw new Error(
+        "Missing the E2E_TEST_VC_PROVIDER environment variable"
+      );
+    } else if (!isValidUrl(process.env.E2E_TEST_VC_PROVIDER)) {
+      throw new Error(
+        `Expected E2E_TEST_VC_PROVIDER environment variable to be an IRI, found: ${
+          process.env.E2E_TEST_VC_PROVIDER}`
+      );
+    }
   }
+    
   // Resource owner static credentials.
   if (
     vars.clientCredentials?.owner?.id &&

--- a/packages/internal-test-env/index.ts
+++ b/packages/internal-test-env/index.ts
@@ -182,35 +182,54 @@ export function getNodeTestingEnvironment(
 }
 
 export interface LibraryVariables {
-  notificationGateway?: string;
-  notificationProtocol?: string;
-  vcProvider?: string;
+  notificationGateway?: boolean;
+  notificationProtocol?: boolean;
+  vcProvider?: boolean;
   clientCredentials?: {
     owner?: {
-      id?: string;
-      secret?: string;
-      login?: string;
-      password?: string;
+      id?: boolean;
+      secret?: boolean;
+      login?: boolean;
+      password?: boolean;
     };
     requestor?: {
-      id?: string;
-      secret?: string;
+      id?: boolean;
+      secret?: boolean;
     };
   };
 }
 
 function validateLibVars(vars: LibraryVariables): object {
+  // Notifications-related environment variables.
   if (
-    typeof vars.notificationGateway !== "undefined" &&
-    typeof vars.notificationGateway !== "string"
+    vars.notificationGateway &&
+    typeof process.env.E2E_TEST_NOTIFICATION_GATEWAY !== "string"
   ) {
     throw new Error(
       "Missing the E2E_TEST_NOTIFICATION_GATEWAY environment variable"
     );
   }
   if (
+    vars.notificationProtocol &&
+    typeof process.env.E2E_TEST_NOTIFICATION_PROTOCOL !== "string"
+  ) {
+    throw new Error(
+      "Missing the E2E_TEST_NOTIFICATION_PROTOCOL environment variable"
+    );
+  }
+  // VC-related environment variables.
+  if (
+    vars.vcProvider &&
+    typeof process.env.E2E_TEST_VC_PROVIDER !== "string"
+  ) {
+    throw new Error(
+      "Missing the E2E_TEST_NOTIFICATION_PROTOCOL environment variable"
+    );
+  }
+  // Resource owner static credentials.
+  if (
     vars.clientCredentials?.owner?.id &&
-    typeof vars.clientCredentials.owner.id !== "string"
+    typeof process.env.E2E_TEST_OWNER_CLIENT_ID !== "string"
   ) {
     throw new Error(
       "Missing the E2E_TEST_OWNER_CLIENT_ID environment variable"
@@ -218,16 +237,16 @@ function validateLibVars(vars: LibraryVariables): object {
   }
   if (
     vars.clientCredentials?.owner?.secret &&
-    typeof vars.clientCredentials.owner.secret !== "string"
+    typeof process.env.E2E_TEST_OWNER_CLIENT_SECRET !== "string"
   ) {
     throw new Error(
       "Missing the E2E_TEST_OWNER_CLIENT_SECRET environment variable"
     );
   }
-
+  // Resource requestor static credentials.
   if (
     vars.clientCredentials?.requestor?.id &&
-    typeof vars.clientCredentials.requestor.id !== "string"
+    typeof process.env.E2E_TEST_REQUESTOR_CLIENT_ID !== "string"
   ) {
     throw new Error(
       "Missing the E2E_TEST_REQUESTOR_CLIENT_ID environment variable"
@@ -235,21 +254,22 @@ function validateLibVars(vars: LibraryVariables): object {
   }
   if (
     vars.clientCredentials?.requestor?.secret &&
-    typeof vars.clientCredentials.requestor.secret !== "string"
+    typeof process.env.E2E_TEST_REQUESTOR_CLIENT_SECRET !== "string"
   ) {
     throw new Error(
       "Missing the E2E_TEST_REQUESTOR_CLIENT_SECRET environment variable"
     );
   }
+  // Resource owner username/password.
   if (
     vars.clientCredentials?.owner?.login &&
-    typeof vars.clientCredentials.owner.login !== "string"
+    typeof process.env.E2E_TEST_USER !== "string"
   ) {
     throw new Error("The environment variable E2E_TEST_USER is undefined.");
   }
   if (
     vars.clientCredentials?.owner?.password &&
-    typeof vars.clientCredentials.owner.password !== "string"
+    typeof process.env.E2E_TEST_PASSWORD !== "string"
   ) {
     throw new Error("The environment variable E2E_TEST_PASSWORD is undefined.");
   }

--- a/packages/internal-test-env/index.ts
+++ b/packages/internal-test-env/index.ts
@@ -157,23 +157,21 @@ function getBaseTestingEnvironment<T extends LibraryVariables>(libVars?: T
 }
 
 export function getNodeTestingEnvironment(
-  libVars?: LibraryVariables
+  varsToValidate?: LibraryVariables
 ): TestingEnvironmentNode {
-  return getBaseTestingEnvironment({
-    ...libVars,
+  return getBaseTestingEnvironment(merge(varsToValidate, {
     // Enforce client credentials are present for the resource owner.
     clientCredentials: { owner: { id: true, secret: true }}
-  });
+  }) as NodeVariables);
 }
 
 export function getBrowserTestingEnvironment(
-  libVars?: LibraryVariables
+  varsToValidate?: LibraryVariables
 ): TestingEnvironmentBrowser {
-  return getBaseTestingEnvironment({
-    ...libVars,
+  return getBaseTestingEnvironment(merge(varsToValidate, {
     // Enforce login/password are present for the resource owner.
     clientCredentials: { owner: { login: true, password: true }}
-  });
+  }) as BrowserVariables);
 }
 
 export interface LibraryVariables {

--- a/packages/internal-test-env/utils.ts
+++ b/packages/internal-test-env/utils.ts
@@ -1,0 +1,30 @@
+//
+// Copyright 2022 Inrupt Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+// Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+// PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+// SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+export function isValidUrl(url: string): boolean {
+  try {
+    // Use URL constructor for validation
+    new URL(url);
+    return true;
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
This changes the environment validation so that booleans are used to flag env vars that should be validated, instead of a value of their type. Meaning 
```
getBrowserTestingEnvironment({
      clientCredentials: {
        owner: { login: "", password: "" },
      },
    });
```
becomes
```getBrowserTestingEnvironment({
      clientCredentials: {
        owner: { login: true, password: true },
      },
    });
```, and the underlying environment variable get type-checked.