### PR TITLE
Load feature flags even in CI

### DIFF
--- a/packages/internal-test-env/README.md
+++ b/packages/internal-test-env/README.md
@@ -23,7 +23,7 @@ This helper exposes the following:
 These two functions will load from the environment variables as follows:
 - Some variables will always be loaded and validated if applicable 
   - `E2E_TEST_ENVIRONMENT`: name of the target environment, used for information purpose.
-    E.g., `Dev-Next`
+    E.g., `ESS Dev-Next`
   - `E2E_TEST_IDP`: IRI of the OpenID Provider where the test session will be retrieved.
   - Any environment variable starting with the pattern `E2E_TEST_FEATURE_*` will be
     made available in a feature flags dictionary keyed by `*`. E.g., `E2E_TEST_FEATURE_NOTIFICATIONS`

--- a/packages/internal-test-env/README.md
+++ b/packages/internal-test-env/README.md
@@ -13,3 +13,30 @@ Add the function import as needed.
 ```
 import "@inrupt/internal-test-env"
 ```
+
+## Features
+
+This helper exposes the following: 
+- `getNodeTestingEnvironment` 
+- `getBrowserTestingEnvironment`
+
+These two functions will load from the environment variables as follows:
+- Some variables will always be loaded and validated if applicable 
+  - `E2E_TEST_ENVIRONMENT`: name of the target environment, used for information purpose.
+    E.g., `Dev-Next`
+  - `E2E_TEST_IDP`: IRI of the OpenID Provider where the test session will be retrieved.
+  - Any environment variable starting with the pattern `E2E_TEST_FEATURE_*` will be
+    made available in a feature flags dictionary keyed by `*`. E.g., `E2E_TEST_FEATURE_NOTIFICATIONS`
+    being defined will result in `features["NOTIFICATIONS"]` to capture the associated
+    value.
+- Some variables will only be loaded and validated if explicitly requested as part
+  of the `get*TestingEnvironment` call:
+    - `E2E_TEST_NOTIFICATION_GATEWAY`
+    - `E2E_TEST_NOTIFICATION_PROTOCOL`
+    - `E2E_TEST_VC_PROVIDER`
+    - `E2E_TEST_OWNER_CLIENT_ID`
+    - `E2E_TEST_OWNER_CLIENT_SECRET`
+    - `E2E_TEST_REQUESTOR_CLIENT_ID`
+    - `E2E_TEST_REQUESTOR_CLIENT_SECRET`
+    - `E2E_TEST_USER`
+    - `E2E_TEST_PASSWORD`

--- a/packages/internal-test-env/index.ts
+++ b/packages/internal-test-env/index.ts
@@ -153,22 +153,22 @@ function getBaseTestingEnvironment<T extends LibraryVariables>(
 export function getNodeTestingEnvironment(
   varsToValidate?: LibraryVariables
 ): TestingEnvironmentNode {
-  return getBaseTestingEnvironment(
+  return getBaseTestingEnvironment<NodeVariables>(
     merge(varsToValidate, {
       // Enforce client credentials are present for the resource owner.
       clientCredentials: { owner: { id: true, secret: true } },
-    }) as NodeVariables
+    })
   );
 }
 
 export function getBrowserTestingEnvironment(
   varsToValidate?: LibraryVariables
 ): TestingEnvironmentBrowser {
-  return getBaseTestingEnvironment(
+  return getBaseTestingEnvironment<BrowserVariables>(
     merge(varsToValidate, {
       // Enforce login/password are present for the resource owner.
       clientCredentials: { owner: { login: true, password: true } },
-    }) as BrowserVariables
+    })
   );
 }
 

--- a/packages/internal-test-env/index.ts
+++ b/packages/internal-test-env/index.ts
@@ -86,27 +86,23 @@ export interface EnvVariables {
 }
 
 export function setupEnv() {
-  if (envLoaded) {
+  // If we're in CI, the environment is already configured. Otherwise, it is
+  // loaded once.
+  if (process.env.CI || envLoaded) {
     return;
   }
-  if (!process.env.CI) {
-    const envPath = join(process.cwd(), "e2e/env/.env.local");
+  const envPath = join(process.cwd(), "e2e/env/.env.local");
 
-    // Otherwise load dotenv configuration
-    config({
-      path: envPath,
-    });
+  // Load dotenv configuration
+  config({
+    path: envPath,
+  });
 
-    if (!process.env.E2E_TEST_ENVIRONMENT) {
-      console.error(
-        `We didn't find the given environment variable E2E_TEST_ENVIRONMENT,
-  tried looking in the following directory for \`.env.local \`: 
-  ${envPath}`
-      );
-    }
+  if (!process.env.E2E_TEST_ENVIRONMENT) {
+    console.error(
+      `We didn't find the given environment variable E2E_TEST_ENVIRONMENT, tried looking in the following directory for '.env.local': ${envPath}`
+    );
   }
-  // If we're in CI, the environment is already configured, and we just loaded
-  // it otherwise.
   envLoaded = true;
 }
 

--- a/packages/internal-test-env/index.ts
+++ b/packages/internal-test-env/index.ts
@@ -132,10 +132,12 @@ function getBaseTestingEnvironment<T extends LibraryVariables>(
   const features = Object.keys(process.env)
     .filter((envVar) => envVar.startsWith(ENV_VAR_PREFIX))
     .reduce(
-      (featureFlags, envVar) => ({
-        ...featureFlags,
-        [`${envVar}`]: process.env[envVar]?.split(ENV_VAR_PREFIX)[1],
-      }),
+      (featureFlags, envVar) => {
+        // Trim the prefix from the environment variable name. 
+        const flagName = envVar.substring(ENV_VAR_PREFIX.length);
+        const flagValue = process.env[envVar];
+        return {...featureFlags, [`${flagName}`]: flagValue};
+      },
       {}
     );
 

--- a/packages/internal-test-env/index.ts
+++ b/packages/internal-test-env/index.ts
@@ -77,6 +77,8 @@ export interface TestingEnvironmentBase {
 type FeatureFlags = {
   [key: string]: any;
 };
+const ENV_VAR_PREFIX = "E2E_TEST_FEATURE_";
+
 let envLoaded = false;
 export interface EnvVariables {
   // Common Envs
@@ -128,11 +130,11 @@ function getBaseTestingEnvironment<T extends LibraryVariables>(
 
   // Creating feature flag object if there are feature flags
   const features = Object.keys(process.env)
-    .filter((envVar) => envVar.startsWith("E2E_TEST_FEATURE_"))
+    .filter((envVar) => envVar.startsWith(ENV_VAR_PREFIX))
     .reduce(
       (featureFlags, envVar) => ({
         ...featureFlags,
-        [`${envVar}`]: process.env[envVar],
+        [`${envVar}`]: process.env[envVar]?.split(ENV_VAR_PREFIX)[1],
       }),
       {}
     );

--- a/packages/internal-test-env/index.ts
+++ b/packages/internal-test-env/index.ts
@@ -78,7 +78,6 @@ type FeatureFlags = {
   [key: string]: any;
 };
 let envLoaded = false;
-let featuredFlags: FeatureFlags = {};
 export interface EnvVariables {
   // Common Envs
   E2E_TEST_ENVIRONMENT: AvailableEnvironment;
@@ -127,14 +126,20 @@ function getBaseTestingEnvironment<T extends LibraryVariables>(
   }
 
   // Creating feature flag object if there are feature flags
-  Object.keys(process.env)
+  const features = Object.keys(process.env)
     .filter((envVar) => envVar.startsWith("E2E_TEST_FEATURE_"))
-    .forEach((key) => (featuredFlags[key] = process.env[key]));
+    .reduce(
+      (featureFlags, envVar) => ({
+        ...featureFlags,
+        [`${envVar}`]: process.env[envVar],
+      }),
+      {}
+    );
 
   const base = {
     idp: targetOp,
     environment: targetEnvName,
-    features: featuredFlags,
+    features,
   };
 
   return libVars ? merge(base, validateLibVars(libVars)) : base;

--- a/packages/internal-test-env/index.ts
+++ b/packages/internal-test-env/index.ts
@@ -131,15 +131,12 @@ function getBaseTestingEnvironment<T extends LibraryVariables>(
   // Creating feature flag object if there are feature flags
   const features = Object.keys(process.env)
     .filter((envVar) => envVar.startsWith(ENV_VAR_PREFIX))
-    .reduce(
-      (featureFlags, envVar) => {
-        // Trim the prefix from the environment variable name. 
-        const flagName = envVar.substring(ENV_VAR_PREFIX.length);
-        const flagValue = process.env[envVar];
-        return {...featureFlags, [`${flagName}`]: flagValue};
-      },
-      {}
-    );
+    .reduce((featureFlags, envVar) => {
+      // Trim the prefix from the environment variable name.
+      const flagName = envVar.substring(ENV_VAR_PREFIX.length);
+      const flagValue = process.env[envVar];
+      return { ...featureFlags, [`${flagName}`]: flagValue };
+    }, {});
 
   const base = {
     idp: targetIdp,

--- a/packages/internal-test-env/index.ts
+++ b/packages/internal-test-env/index.ts
@@ -36,7 +36,6 @@ export const availableEnvironment = [
   "ESS Dev-Next" as const,
   "ESS PodSpaces" as const,
   "NSS" as const,
-  //  "ESS PodSpaces Next" as const,
 ];
 
 export type AvailableEnvironment = typeof availableEnvironment extends Array<
@@ -109,44 +108,35 @@ export function setupEnv() {
   // If we're in CI, the environment is already configured, and we just loaded
   // it otherwise.
   envLoaded = true;
-
-  // Creating feature flag object if there are feature flags
-  Object.keys(process.env)
-    .filter((envVar) => envVar.startsWith("E2E_TEST_FEATURE_"))
-    .forEach((key) => (featuredFlags[key] = process.env[key]));
-}
-
-function getTestingEnvironment(
-  environment: unknown
-): asserts environment is EnvVariables {
-  // Populate your process.env from your .env file of choice
-
-  // TODO: Replace these inline validations and checks with envalid or env-var
-  if (
-    !availableEnvironment.includes(
-      (environment as EnvVariables).E2E_TEST_ENVIRONMENT as AvailableEnvironment
-    )
-  ) {
-    throw new Error(
-      `Unknown environment: [${
-        (environment as EnvVariables).E2E_TEST_ENVIRONMENT
-      }]`
-    );
-  }
-
-  if (typeof (environment as EnvVariables).E2E_TEST_IDP !== "string") {
-    throw new Error("The environment variable E2E_TEST_IDP is undefined.");
-  }
 }
 
 function getBaseTestingEnvironment<T extends LibraryVariables>(libVars?: T
   ): T extends NodeVariables ? TestingEnvironmentNode : TestingEnvironmentBrowser   {
     setupEnv();
-    getTestingEnvironment(process.env);
+    // TODO: Replace these inline validations and checks with envalid or env-var
+    
+    // Load and validate target environment name.
+    const targetEnvName = process.env.E2E_TEST_ENVIRONMENT;
+    if (
+      !availableEnvironment.includes(targetEnvName as AvailableEnvironment)
+    ) {
+      throw new Error(`Unknown environment: [${targetEnvName}]`);
+    }
+
+    // Load and validate target OpenID Provider.
+    const targetOp = process.env.E2E_TEST_IDP;
+    if (typeof targetOp !== "string") {
+      throw new Error("The environment variable E2E_TEST_IDP is undefined.");
+    }
+
+    // Creating feature flag object if there are feature flags
+    Object.keys(process.env)
+    .filter((envVar) => envVar.startsWith("E2E_TEST_FEATURE_"))
+    .forEach((key) => (featuredFlags[key] = process.env[key]));
   
     const base = {
-      idp: process.env.E2E_TEST_IDP,
-      environment: process.env.E2E_TEST_ENVIRONMENT,
+      idp: targetOp,
+      environment: targetEnvName,
       features: featuredFlags,
     };
   

--- a/packages/internal-test-env/index.ts
+++ b/packages/internal-test-env/index.ts
@@ -120,8 +120,10 @@ function getBaseTestingEnvironment<T extends LibraryVariables>(
 
   // Load and validate target OpenID Provider.
   const targetOp = process.env.E2E_TEST_IDP;
-  if (typeof targetOp !== "string") {
-    throw new Error("The environment variable E2E_TEST_IDP is undefined.");
+  if (typeof targetOp !== "string" || !isValidUrl(targetOp)) {
+    throw new Error(
+      `The environment variable E2E_TEST_IDP is not a valid URL: found ${targetOp}.`
+    );
   }
 
   // Creating feature flag object if there are feature flags

--- a/packages/internal-test-env/index.ts
+++ b/packages/internal-test-env/index.ts
@@ -111,7 +111,6 @@ function getBaseTestingEnvironment<T extends LibraryVariables>(
   ? TestingEnvironmentNode
   : TestingEnvironmentBrowser {
   setupEnv();
-  // TODO: Replace these inline validations and checks with envalid or env-var
 
   // Load and validate target environment name.
   const targetEnvName = process.env.E2E_TEST_ENVIRONMENT;

--- a/packages/internal-test-env/index.ts
+++ b/packages/internal-test-env/index.ts
@@ -32,13 +32,13 @@ import {
 } from "@inrupt/solid-client";
 import { isValidUrl } from "./utils";
 
-export const availableEnvironment = [
+export const availableEnvironments = [
   "ESS Dev-Next" as const,
   "ESS PodSpaces" as const,
   "NSS" as const,
 ];
 
-export type AvailableEnvironment = typeof availableEnvironment extends Array<
+export type AvailableEnvironments = typeof availableEnvironments extends Array<
   infer E
 >
   ? E
@@ -66,7 +66,7 @@ export interface TestingEnvironmentBrowser extends TestingEnvironmentBase {
 }
 
 export interface TestingEnvironmentBase {
-  environment: AvailableEnvironment;
+  environment: AvailableEnvironments;
   idp: string;
   features: FeatureFlags | undefined;
   notificationGateway?: string;
@@ -80,7 +80,7 @@ type FeatureFlags = {
 let envLoaded = false;
 export interface EnvVariables {
   // Common Envs
-  E2E_TEST_ENVIRONMENT: AvailableEnvironment;
+  E2E_TEST_ENVIRONMENT: AvailableEnvironments;
   E2E_TEST_IDP: string;
 }
 
@@ -114,7 +114,7 @@ function getBaseTestingEnvironment<T extends LibraryVariables>(
 
   // Load and validate target environment name.
   const targetEnvName = process.env.E2E_TEST_ENVIRONMENT;
-  if (!availableEnvironment.includes(targetEnvName as AvailableEnvironment)) {
+  if (!availableEnvironments.includes(targetEnvName as AvailableEnvironments)) {
     throw new Error(`Unknown environment: [${targetEnvName}]`);
   }
 

--- a/packages/internal-test-env/index.ts
+++ b/packages/internal-test-env/index.ts
@@ -121,10 +121,10 @@ function getBaseTestingEnvironment<T extends LibraryVariables>(
   }
 
   // Load and validate target OpenID Provider.
-  const targetOp = process.env.E2E_TEST_IDP;
-  if (typeof targetOp !== "string" || !isValidUrl(targetOp)) {
+  const targetIdp = process.env.E2E_TEST_IDP;
+  if (typeof targetIdp !== "string" || !isValidUrl(targetIdp)) {
     throw new Error(
-      `The environment variable E2E_TEST_IDP is not a valid URL: found ${targetOp}.`
+      `The environment variable E2E_TEST_IDP is not a valid URL: found ${targetIdp}.`
     );
   }
 
@@ -142,7 +142,7 @@ function getBaseTestingEnvironment<T extends LibraryVariables>(
     );
 
   const base = {
-    idp: targetOp,
+    idp: targetIdp,
     environment: targetEnvName,
     features,
   };

--- a/packages/internal-test-env/index.ts
+++ b/packages/internal-test-env/index.ts
@@ -77,7 +77,7 @@ export interface TestingEnvironmentBase {
 type FeatureFlags = {
   [key: string]: any;
 };
-const ENV_VAR_PREFIX = "E2E_TEST_FEATURE_";
+const ENV_FEATURE_PREFIX = "E2E_TEST_FEATURE_";
 
 let envLoaded = false;
 export interface EnvVariables {
@@ -130,10 +130,10 @@ function getBaseTestingEnvironment<T extends LibraryVariables>(
 
   // Creating feature flag object if there are feature flags
   const features = Object.keys(process.env)
-    .filter((envVar) => envVar.startsWith(ENV_VAR_PREFIX))
+    .filter((envVar) => envVar.startsWith(ENV_FEATURE_PREFIX))
     .reduce((featureFlags, envVar) => {
       // Trim the prefix from the environment variable name.
-      const flagName = envVar.substring(ENV_VAR_PREFIX.length);
+      const flagName = envVar.substring(ENV_FEATURE_PREFIX.length);
       const flagValue = process.env[envVar];
       return { ...featureFlags, [`${flagName}`]: flagValue };
     }, {});

--- a/packages/internal-test-env/index.ts
+++ b/packages/internal-test-env/index.ts
@@ -87,36 +87,33 @@ export interface EnvVariables {
 }
 
 export function setupEnv() {
-  // If we're in CI, the environment is already configured.
-  if (process.env.CI) {
-    return;
-  }
-
   if (envLoaded) {
     return;
   }
+  if (!process.env.CI) {
+    const envPath = join(process.cwd(), "e2e/env/.env.local");
 
-  const envPath = join(process.cwd(), "e2e/env/.env.local");
+    // Otherwise load dotenv configuration
+    config({
+      path: envPath,
+    });
 
-  // Otherwise load dotenv configuration
-  config({
-    path: envPath,
-  });
-
-  if (!process.env.E2E_TEST_ENVIRONMENT) {
-    console.error(
-      `We didn't find the given environment variable E2E_TEST_ENVIRONMENT,
-tried looking in the following directory for \`.env.local \`: 
-${envPath}`
-    );
+    if (!process.env.E2E_TEST_ENVIRONMENT) {
+      console.error(
+        `We didn't find the given environment variable E2E_TEST_ENVIRONMENT,
+  tried looking in the following directory for \`.env.local \`: 
+  ${envPath}`
+      );
+    }
   }
+  // If we're in CI, the environment is already configured, and we just loaded
+  // it otherwise.
+  envLoaded = true;
 
   // Creating feature flag object if there are feature flags
   Object.keys(process.env)
     .filter((envVar) => envVar.startsWith("E2E_TEST_FEATURE_"))
     .forEach((key) => (featuredFlags[key] = process.env[key]));
-  // Marking env as loaded
-  envLoaded = true;
 }
 
 function getTestingEnvironment(

--- a/packages/internal-test-env/index.ts
+++ b/packages/internal-test-env/index.ts
@@ -106,55 +106,60 @@ export function setupEnv() {
   envLoaded = true;
 }
 
-function getBaseTestingEnvironment<T extends LibraryVariables>(libVars?: T
-  ): T extends NodeVariables ? TestingEnvironmentNode : TestingEnvironmentBrowser   {
-    setupEnv();
-    // TODO: Replace these inline validations and checks with envalid or env-var
-    
-    // Load and validate target environment name.
-    const targetEnvName = process.env.E2E_TEST_ENVIRONMENT;
-    if (
-      !availableEnvironment.includes(targetEnvName as AvailableEnvironment)
-    ) {
-      throw new Error(`Unknown environment: [${targetEnvName}]`);
-    }
+function getBaseTestingEnvironment<T extends LibraryVariables>(
+  libVars?: T
+): T extends NodeVariables
+  ? TestingEnvironmentNode
+  : TestingEnvironmentBrowser {
+  setupEnv();
+  // TODO: Replace these inline validations and checks with envalid or env-var
 
-    // Load and validate target OpenID Provider.
-    const targetOp = process.env.E2E_TEST_IDP;
-    if (typeof targetOp !== "string") {
-      throw new Error("The environment variable E2E_TEST_IDP is undefined.");
-    }
+  // Load and validate target environment name.
+  const targetEnvName = process.env.E2E_TEST_ENVIRONMENT;
+  if (!availableEnvironment.includes(targetEnvName as AvailableEnvironment)) {
+    throw new Error(`Unknown environment: [${targetEnvName}]`);
+  }
 
-    // Creating feature flag object if there are feature flags
-    Object.keys(process.env)
+  // Load and validate target OpenID Provider.
+  const targetOp = process.env.E2E_TEST_IDP;
+  if (typeof targetOp !== "string") {
+    throw new Error("The environment variable E2E_TEST_IDP is undefined.");
+  }
+
+  // Creating feature flag object if there are feature flags
+  Object.keys(process.env)
     .filter((envVar) => envVar.startsWith("E2E_TEST_FEATURE_"))
     .forEach((key) => (featuredFlags[key] = process.env[key]));
-  
-    const base = {
-      idp: targetOp,
-      environment: targetEnvName,
-      features: featuredFlags,
-    };
-  
-    return libVars ? merge(base, validateLibVars(libVars)) : base;
+
+  const base = {
+    idp: targetOp,
+    environment: targetEnvName,
+    features: featuredFlags,
+  };
+
+  return libVars ? merge(base, validateLibVars(libVars)) : base;
 }
 
 export function getNodeTestingEnvironment(
   varsToValidate?: LibraryVariables
 ): TestingEnvironmentNode {
-  return getBaseTestingEnvironment(merge(varsToValidate, {
-    // Enforce client credentials are present for the resource owner.
-    clientCredentials: { owner: { id: true, secret: true }}
-  }) as NodeVariables);
+  return getBaseTestingEnvironment(
+    merge(varsToValidate, {
+      // Enforce client credentials are present for the resource owner.
+      clientCredentials: { owner: { id: true, secret: true } },
+    }) as NodeVariables
+  );
 }
 
 export function getBrowserTestingEnvironment(
   varsToValidate?: LibraryVariables
 ): TestingEnvironmentBrowser {
-  return getBaseTestingEnvironment(merge(varsToValidate, {
-    // Enforce login/password are present for the resource owner.
-    clientCredentials: { owner: { login: true, password: true }}
-  }) as BrowserVariables);
+  return getBaseTestingEnvironment(
+    merge(varsToValidate, {
+      // Enforce login/password are present for the resource owner.
+      clientCredentials: { owner: { login: true, password: true } },
+    }) as BrowserVariables
+  );
 }
 
 export interface LibraryVariables {
@@ -202,41 +207,34 @@ function validateLibVars(varsToValidate: LibraryVariables): object {
       );
     } else if (!isValidUrl(process.env.E2E_TEST_NOTIFICATION_GATEWAY)) {
       throw new Error(
-        `Expected E2E_TEST_NOTIFICATION_GATEWAY environment variable to be an IRI, found: ${
-          process.env.E2E_TEST_NOTIFICATION_GATEWAY}`
+        `Expected E2E_TEST_NOTIFICATION_GATEWAY environment variable to be an IRI, found: ${process.env.E2E_TEST_NOTIFICATION_GATEWAY}`
       );
     }
   }
 
   if (varsToValidate.notificationProtocol) {
-    if (typeof process.env.E2E_TEST_NOTIFICATION_PROTOCOL !== "string"
-    ) {
+    if (typeof process.env.E2E_TEST_NOTIFICATION_PROTOCOL !== "string") {
       throw new Error(
         "Missing the E2E_TEST_NOTIFICATION_PROTOCOL environment variable"
       );
     } else if (!isValidUrl(process.env.E2E_TEST_NOTIFICATION_PROTOCOL)) {
       throw new Error(
-        `Expected E2E_TEST_NOTIFICATION_PROTOCOL environment variable to be an IRI, found: ${
-          process.env.E2E_TEST_NOTIFICATION_PROTOCOL}`
+        `Expected E2E_TEST_NOTIFICATION_PROTOCOL environment variable to be an IRI, found: ${process.env.E2E_TEST_NOTIFICATION_PROTOCOL}`
       );
     }
   }
-    
+
   // VC-related environment variables.
   if (varsToValidate.vcProvider) {
-    if (typeof process.env.E2E_TEST_VC_PROVIDER !== "string"
-    ) {
-      throw new Error(
-        "Missing the E2E_TEST_VC_PROVIDER environment variable"
-      );
+    if (typeof process.env.E2E_TEST_VC_PROVIDER !== "string") {
+      throw new Error("Missing the E2E_TEST_VC_PROVIDER environment variable");
     } else if (!isValidUrl(process.env.E2E_TEST_VC_PROVIDER)) {
       throw new Error(
-        `Expected E2E_TEST_VC_PROVIDER environment variable to be an IRI, found: ${
-          process.env.E2E_TEST_VC_PROVIDER}`
+        `Expected E2E_TEST_VC_PROVIDER environment variable to be an IRI, found: ${process.env.E2E_TEST_VC_PROVIDER}`
       );
     }
   }
-    
+
   // Resource owner static credentials.
   if (
     varsToValidate.clientCredentials?.owner?.id &&


### PR DESCRIPTION
Currently, feature flags are correctly loaded locally, but they fail to load in CI. This is due to the fact that they only get loaded after `dotenv` runs, which only happens on dev machines but not in CI.