### PR TITLE
chore(deps): move dotenv to dependencies as it is used at runtime

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4564,7 +4564,6 @@
     },
     "node_modules/dotenv": {
       "version": "16.0.3",
-      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"
@@ -10986,10 +10985,10 @@
         "@inrupt/solid-client": "^1.23.3",
         "@inrupt/solid-client-authn-browser": "^1.12.2",
         "@inrupt/solid-client-authn-node": "^1.12.2",
-        "deepmerge-json": "^1.5.0"
+        "deepmerge-json": "^1.5.0",
+        "dotenv": "^16.0.3"
       },
       "devDependencies": {
-        "dotenv": "^16.0.3",
         "rollup": "^3.3.0",
         "rollup-plugin-typescript2": "^0.34.1",
         "tslib": "^2.4.1",
@@ -14003,8 +14002,7 @@
       }
     },
     "dotenv": {
-      "version": "16.0.3",
-      "dev": true
+      "version": "16.0.3"
     },
     "duplexer": {
       "version": "0.1.2"

--- a/packages/internal-test-env/package.json
+++ b/packages/internal-test-env/package.json
@@ -21,10 +21,10 @@
     "@inrupt/solid-client": "^1.23.3",
     "@inrupt/solid-client-authn-browser": "^1.12.2",
     "@inrupt/solid-client-authn-node": "^1.12.2",
-    "deepmerge-json": "^1.5.0"
+    "deepmerge-json": "^1.5.0",
+    "dotenv": "^16.0.3"
   },
   "devDependencies": {
-    "dotenv": "^16.0.3",
     "rollup": "^3.3.0",
     "rollup-plugin-typescript2": "^0.34.1",
     "tslib": "^2.4.1",


### PR DESCRIPTION
This meant that dotenv wasn't available at runtime for consumers, so without them having directly installed dotenv, this package would crash.