### PR TITLE
Fix dependabot config for npm workspaces

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,11 +6,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    open-pull-requests-limit: 10
-  - package-ecosystem: npm
-    directory: "/packages/*"
-    schedule:
-      interval: "weekly"
+    # The following is required for workspaces to be updated: see https://github.com/dependabot/dependabot-core/issues/5226.
+    versioning-strategy: increase
     open-pull-requests-limit: 10
   - package-ecosystem: npm
     directory: "/eslint-configs/*"


### PR DESCRIPTION
In the absence of a lockfile for sub-projects, the default dependabot update strategy only updates dev dependencies in the main lockfile. The "increase" versioning strategy enforces that the package.json is updated as well.