### PR TITLE
Updating license header to reflect current year

### DIFF
--- a/eslint-configs/eslint-config-base/license-header.js
+++ b/eslint-configs/eslint-config-base/license-header.js
@@ -1,5 +1,5 @@
 //
-// Copyright 2022 Inrupt Inc.
+// Copyright 2023 Inrupt Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal in


### PR DESCRIPTION
Updating template for license-header.js that gets used to fix files with missing license headers