### PR TITLE
breaking changes: remove license year and enforce use of type-only imports

### DIFF
--- a/e2e/browser/test-app/components/appContainer/index.tsx
+++ b/e2e/browser/test-app/components/appContainer/index.tsx
@@ -1,5 +1,5 @@
 //
-// Copyright 2022 Inrupt Inc.
+// Copyright Inrupt Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal in

--- a/e2e/browser/test-app/components/solidClient/index.tsx
+++ b/e2e/browser/test-app/components/solidClient/index.tsx
@@ -1,5 +1,5 @@
 //
-// Copyright 2022 Inrupt Inc.
+// Copyright Inrupt Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal in

--- a/e2e/browser/test-app/pages/_app.tsx
+++ b/e2e/browser/test-app/pages/_app.tsx
@@ -1,5 +1,5 @@
 //
-// Copyright 2022 Inrupt Inc.
+// Copyright Inrupt Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal in

--- a/e2e/browser/test-app/pages/index.tsx
+++ b/e2e/browser/test-app/pages/index.tsx
@@ -1,5 +1,5 @@
 //
-// Copyright 2022 Inrupt Inc.
+// Copyright Inrupt Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal in

--- a/e2e/browser/test/e2e.playwright.ts
+++ b/e2e/browser/test/e2e.playwright.ts
@@ -1,5 +1,5 @@
 //
-// Copyright 2022 Inrupt Inc.
+// Copyright Inrupt Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal in

--- a/e2e/browser/test/globalSetup.ts
+++ b/e2e/browser/test/globalSetup.ts
@@ -1,5 +1,5 @@
 //
-// Copyright 2022 Inrupt Inc.
+// Copyright Inrupt Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal in

--- a/eslint-configs/eslint-config-base/index.js
+++ b/eslint-configs/eslint-config-base/index.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 Inrupt Inc.
+Copyright Inrupt Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal in

--- a/eslint-configs/eslint-config-base/license-header.js
+++ b/eslint-configs/eslint-config-base/license-header.js
@@ -1,5 +1,5 @@
 //
-// Copyright 2023 Inrupt Inc.
+// Copyright Inrupt Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal in

--- a/eslint-configs/eslint-config-lib/index.js
+++ b/eslint-configs/eslint-config-lib/index.js
@@ -58,6 +58,22 @@ module.exports = {
         // Use typescript's definition checker
         "no-use-before-define": ["off"],
         "@typescript-eslint/no-use-before-define": ["warn"],
+
+        // Ensure that type only imports are used whenever possible; this is also important
+        // to avoid violating the import/no-unresolved rule when type-only packages such as
+        // @rdfjs/types are used
+        //
+        // For instance if we have:
+        // ```ts
+        // import { Term } from '@rdfjs/types';
+        // ```
+        // Then the import/no-unresolved rule is violated; but eslint --fix is unable to resolve
+        // the problem. By adding this rule eslint --fix is able to set this to:
+        // ```ts
+        // import type { Term } from '@rdfjs/types';
+        // ```
+        //
+        "@typescript-eslint/consistent-type-imports": ["error", { prefer: "type-imports" }],
       },
     },
   ],

--- a/eslint-configs/eslint-config-lib/index.js
+++ b/eslint-configs/eslint-config-lib/index.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 Inrupt Inc.
+Copyright Inrupt Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal in

--- a/eslint-configs/eslint-config-react/index.js
+++ b/eslint-configs/eslint-config-react/index.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 Inrupt Inc.
+Copyright Inrupt Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal in

--- a/packages/internal-playwright-helpers/src/flows/auth.ts
+++ b/packages/internal-playwright-helpers/src/flows/auth.ts
@@ -1,5 +1,5 @@
 //
-// Copyright 2022 Inrupt Inc.
+// Copyright Inrupt Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal in

--- a/packages/internal-playwright-helpers/src/index.ts
+++ b/packages/internal-playwright-helpers/src/index.ts
@@ -1,5 +1,5 @@
 //
-// Copyright 2022 Inrupt Inc.
+// Copyright Inrupt Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal in

--- a/packages/internal-playwright-helpers/src/pages/cognito.ts
+++ b/packages/internal-playwright-helpers/src/pages/cognito.ts
@@ -1,5 +1,5 @@
 //
-// Copyright 2022 Inrupt Inc.
+// Copyright Inrupt Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal in

--- a/packages/internal-playwright-helpers/src/pages/open-id.ts
+++ b/packages/internal-playwright-helpers/src/pages/open-id.ts
@@ -1,5 +1,5 @@
 //
-// Copyright 2022 Inrupt Inc.
+// Copyright Inrupt Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal in

--- a/packages/internal-playwright-helpers/src/pages/testPage.ts
+++ b/packages/internal-playwright-helpers/src/pages/testPage.ts
@@ -1,5 +1,5 @@
 //
-// Copyright 2022 Inrupt Inc.
+// Copyright Inrupt Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal in

--- a/packages/internal-test-env/index.ts
+++ b/packages/internal-test-env/index.ts
@@ -1,5 +1,5 @@
 //
-// Copyright 2022 Inrupt Inc.
+// Copyright Inrupt Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal in

--- a/packages/internal-test-env/utils.ts
+++ b/packages/internal-test-env/utils.ts
@@ -1,5 +1,5 @@
 //
-// Copyright 2022 Inrupt Inc.
+// Copyright Inrupt Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal in

--- a/packages/jest-jsdom-polyfills/index.js
+++ b/packages/jest-jsdom-polyfills/index.js
@@ -1,5 +1,5 @@
 //
-// Copyright 2022 Inrupt Inc.
+// Copyright Inrupt Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal in

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,5 +1,5 @@
 //
-// Copyright 2022 Inrupt Inc.
+// Copyright Inrupt Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal in


### PR DESCRIPTION
Supercedes https://github.com/inrupt/typescript-sdk-tools/pull/66.