### PR TITLE
chore: add option to lint prior to build

### DIFF
--- a/.github/workflows/reusable-lint.yml
+++ b/.github/workflows/reusable-lint.yml
@@ -7,7 +7,11 @@ on:
         required: false
         default: false
         type: boolean
-
+      build:
+        required: false
+        default: false
+        type: boolean
+        
 jobs:
   lint:
     runs-on: ubuntu-latest
@@ -22,5 +26,8 @@ jobs:
         run: npx @skypack/package-check
       # Install dependencies:
       - run: npm ci --ignore-scripts
+      # Build the package(s)
+      - if: ${{inputs.build}}
+        run: npm run build
       # Run the linting command:
       - run: npm run lint


### PR DESCRIPTION
Removes the need for a custom linting script in the authn libraries per https://github.com/inrupt/solid-client-authn-js/pull/3044#discussion_r1257390150