### PR TITLE
feat: rollup config

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14662,6 +14662,7 @@
       }
     },
     "packages/base-rollup-config": {
+      "name": "@inrupt/base-rollup-config",
       "version": "2.1.1",
       "license": "MIT"
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -840,6 +840,10 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@inrupt/base-rollup-config": {
+      "resolved": "packages/base-rollup-config",
+      "link": true
+    },
     "node_modules/@inrupt/eslint-config-base": {
       "resolved": "eslint-configs/eslint-config-base",
       "link": true
@@ -14657,6 +14661,10 @@
         "url": "https://github.com/sponsors/colinhacks"
       }
     },
+    "packages/base-rollup-config": {
+      "version": "2.1.1",
+      "license": "MIT"
+    },
     "packages/internal-playwright-helpers": {
       "name": "@inrupt/internal-playwright-helpers",
       "version": "2.1.1",
@@ -15200,6 +15208,9 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/@hutson/parse-repository-url/-/parse-repository-url-3.0.2.tgz",
       "integrity": "sha512-H9XAx3hc0BQHY6l+IFSWHDySypcXsvsuLhgYLUGywmJ5pswRVQJUHpOsobnLYp2ZUaUlKiKDrgWWhosOwAEM8Q=="
+    },
+    "@inrupt/base-rollup-config": {
+      "version": "file:packages/base-rollup-config"
     },
     "@inrupt/eslint-config-base": {
       "version": "file:eslint-configs/eslint-config-base",

--- a/packages/base-rollup-config/README.md
+++ b/packages/base-rollup-config/README.md
@@ -9,10 +9,13 @@ This package contains the base configuration for rollup across our packages
 ## Usage:
 
 Can be used in rollup.config.mjs as follows
-```
+```mjs
 import { createRequire } from "node:module";
 import createConfig from "@inrupt/base-rollup-config";
 const require = createRequire(import.meta.url);
 
 export default createConfig(require("./package.json"));
 ```
+
+Make sure to specify `main` (cjs), `module` (esm) and `types` entrypoints in the package.json as rollup uses
+these entries to determine where to write the output.

--- a/packages/base-rollup-config/README.md
+++ b/packages/base-rollup-config/README.md
@@ -8,7 +8,8 @@ This package contains the base configuration for rollup across our packages
 
 ## Usage:
 
-Can be used in rollup.config.mjs as follows
+Can be used in rollup.config.mjs as follows:
+
 ```mjs
 import { createRequire } from "node:module";
 import createConfig from "@inrupt/base-rollup-config";

--- a/packages/base-rollup-config/README.md
+++ b/packages/base-rollup-config/README.md
@@ -1,0 +1,18 @@
+# @inrupt/base-rollup-config
+
+This package contains the base configuration for rollup across our packages
+
+## Installation
+
+1. `npm install --save-dev @inrupt/base-rollup-config`
+
+## Usage:
+
+Can be used in rollup.config.mjs as follows
+```
+import { createRequire } from "node:module";
+import createConfig from "@inrupt/base-rollup-config";
+const require = createRequire(import.meta.url);
+
+export default createConfig(require("./package.json"));
+```

--- a/packages/base-rollup-config/index.mjs
+++ b/packages/base-rollup-config/index.mjs
@@ -1,0 +1,59 @@
+//
+// Copyright Inrupt Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to use,
+// copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+// Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+// INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+// PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+// SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+import typescript from "rollup-plugin-typescript2";
+import { createRequire } from "node:module";
+const require = createRequire(import.meta.url);
+
+export const createSharedConfig = pkg => ({
+  plugins: [
+    typescript({
+      // Use our own version of TypeScript, rather than the one bundled with the plugin:
+      typescript: require("typescript"),
+      tsconfigOverride: {
+        compilerOptions: {
+          module: "esnext",
+        },
+      },
+    }),
+  ],
+  external: Object.keys(pkg.dependencies),
+  // The following option is useful because symlinks are used in monorepos
+  preserveSymlinks: true,
+});
+
+export default pkg => [
+  {
+    input: "./src/index.ts",
+    output: [
+      {
+        file: pkg.module,
+        format: "esm",
+        sourcemap: true,
+      },
+      {
+        file: pkg.main,
+        format: "cjs",
+        sourcemap: true,
+      },
+    ],
+    ...createSharedConfig(pkg),
+  },
+];

--- a/packages/base-rollup-config/package.json
+++ b/packages/base-rollup-config/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@inrupt/base-rollup-config",
+  "version": "2.1.1",
+  "description": "This package provides a shared rollup config for our packages",
+  "module": "index.mjs",
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/inrupt/typescript-sdk-tools.git"
+  },
+  "keywords": [
+    "inrupt",
+    "rollup",
+    "bundler"
+  ],
+  "author": "Inrupt <engineering@inrupt.com>",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/inrupt/typescript-sdk-tools/issues"
+  },
+  "homepage": "https://github.com/inrupt/typescript-sdk-tools#readme"
+}

--- a/packages/base-rollup-config/package.json
+++ b/packages/base-rollup-config/package.json
@@ -2,7 +2,8 @@
   "name": "@inrupt/base-rollup-config",
   "version": "2.1.1",
   "description": "This package provides a shared rollup config for our packages",
-  "module": "index.mjs",
+  "main": "index.mjs",
+  "module": "true",
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
Moving the shared config from https://github.com/inrupt/solid-client-authn-js/blob/main/rollup.common.mjs to a package so it can be shared between all of our libs.