### PR TITLE
SDK-3193: Fix OpenID prompt locators

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,3 +18,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,6 +19,6 @@ updates:
     schedule:
       interval: "weekly"
   - package-ecosystem: npm
-    directory: "/"
+    directory: "e2e/browser/test-app"
     schedule:
       interval: "weekly"

--- a/e2e/browser/test-app/package-lock.json
+++ b/e2e/browser/test-app/package-lock.json
@@ -8,8 +8,8 @@
       "name": "test",
       "version": "0.1.0",
       "dependencies": {
-        "@inrupt/solid-client": "^1.29.0",
-        "@inrupt/solid-client-authn-browser": "^1.16.0",
+        "@inrupt/solid-client": "^1.30.0",
+        "@inrupt/solid-client-authn-browser": "^1.17.1",
         "next": "^13.4.6",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
@@ -134,20 +134,21 @@
       }
     },
     "node_modules/@inrupt/oidc-client-ext": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@inrupt/oidc-client-ext/-/oidc-client-ext-1.16.0.tgz",
-      "integrity": "sha512-09fJEX64GFq6eWY5xSFsKWo9Uz2v14s2L2It49/KnzAe7O9hc8XXelNndLPxrrOOzuf38YHv4W1irFJPy4PPMw==",
+      "version": "1.17.1",
+      "resolved": "https://registry.npmjs.org/@inrupt/oidc-client-ext/-/oidc-client-ext-1.17.1.tgz",
+      "integrity": "sha512-uh8ecf4xALoel6Yxlg8srsGO44JhQLjE++mdM13Fniy6TwCU+odHSnMny9afpO/HBZ6abQ02mCFiLtrufczzaA==",
       "dependencies": {
         "@inrupt/oidc-client": "^1.11.6",
-        "@inrupt/solid-client-authn-core": "^1.16.0",
+        "@inrupt/solid-client-authn-core": "^1.17.1",
+        "@inrupt/universal-fetch": "^1.0.1",
         "jose": "^4.10.0",
         "uuid": "^9.0.0"
       }
     },
     "node_modules/@inrupt/solid-client": {
-      "version": "1.29.0",
-      "resolved": "https://registry.npmjs.org/@inrupt/solid-client/-/solid-client-1.29.0.tgz",
-      "integrity": "sha512-n5kspeQnrj2h57q4q14bnzC64yPZ/1Y+nvkKy6hamurzsxuRNN/D3tpNjRN4QSTfIE7Yi/swUhu7q5NZ6uASgg==",
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/@inrupt/solid-client/-/solid-client-1.30.0.tgz",
+      "integrity": "sha512-iRyLqM9k5W0IiRHZz+dGsa+94pu8cGqjRB5B8s+YhLlNQH/fY6Xmu21f1zl1uKWebc4PBlAJPcBcR46RVXlCJQ==",
       "dependencies": {
         "@inrupt/universal-fetch": "^1.0.1",
         "@rdfjs/dataset": "^1.1.0",
@@ -167,31 +168,26 @@
       }
     },
     "node_modules/@inrupt/solid-client-authn-browser": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@inrupt/solid-client-authn-browser/-/solid-client-authn-browser-1.16.0.tgz",
-      "integrity": "sha512-6Wq/e8C5RapSFTRhs7TKThwhLaQ2DdMqmAiqaNlP7XpTWKRv87Chc2sX0msPjzmM+L/Tde2+71lX1o0x6sQbKA==",
+      "version": "1.17.1",
+      "resolved": "https://registry.npmjs.org/@inrupt/solid-client-authn-browser/-/solid-client-authn-browser-1.17.1.tgz",
+      "integrity": "sha512-ApTK9H+v6YOp099opLdyLq9qM5j8adpYkK4KMOQKsK9ndDLVNiduq4EgPq4/jtwPGe0hG0YWuFuB8mJpLzJftA==",
       "dependencies": {
-        "@inrupt/oidc-client-ext": "^1.16.0",
-        "@inrupt/solid-client-authn-core": "^1.16.0",
-        "@inrupt/universal-fetch": "^1.0.1",
-        "@types/lodash.clonedeep": "^4.5.6",
-        "@types/node": "^20.1.0",
-        "@types/uuid": "^9.0.1",
+        "@inrupt/oidc-client-ext": "^1.17.1",
+        "@inrupt/solid-client-authn-core": "^1.17.1",
+        "@inrupt/universal-fetch": "^1.0.2",
         "events": "^3.3.0",
         "jose": "^4.3.7",
-        "lodash.clonedeep": "^4.5.0",
         "uuid": "^9.0.0"
       }
     },
     "node_modules/@inrupt/solid-client-authn-core": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@inrupt/solid-client-authn-core/-/solid-client-authn-core-1.16.0.tgz",
-      "integrity": "sha512-lp4p21Ob0SJwPW2mJcUkM6YBp/zj9MM+RlHRM1uUdpPgvybGDLEIgJfKjkjku0RqFFJwCSP/KtbdCgnNFk5KXw==",
+      "version": "1.17.1",
+      "resolved": "https://registry.npmjs.org/@inrupt/solid-client-authn-core/-/solid-client-authn-core-1.17.1.tgz",
+      "integrity": "sha512-UKTtZH0lISgWaiUYRr0zRkvFHIjYzVaWEC0IJoLUFIEfJdYogMXmPKoHyJEw7MdJ6qVYMLdPo9k2OSLfdUfYjA==",
       "dependencies": {
         "@inrupt/universal-fetch": "^1.0.1",
         "events": "^3.3.0",
         "jose": "^4.10.0",
-        "lodash.clonedeep": "^4.5.0",
         "uuid": "^9.0.0"
       },
       "engines": {
@@ -199,12 +195,15 @@
       }
     },
     "node_modules/@inrupt/universal-fetch": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@inrupt/universal-fetch/-/universal-fetch-1.0.1.tgz",
-      "integrity": "sha512-oqbG7jS1fa6hVkjSir+u5Ab3eSbyxFyOjsgjDICL27mAd5z8oImTSETnY2hYbkRaJQYKMBOXhtm7L5/+EbeVJg==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@inrupt/universal-fetch/-/universal-fetch-1.0.3.tgz",
+      "integrity": "sha512-AP/nMOuuKvR2YoQkdS77ntuuq5ZYDGStI8Uirp1MCsyPSoBLyNnRjMLjlGqIlaC+5Xp7TYZJ9z/Kl2uUEpXUFw==",
       "dependencies": {
         "node-fetch": "^2.6.7",
         "undici": "^5.19.1"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.0.0 || ^18.0.0 || ^20.0.0"
       }
     },
     "node_modules/@next/env": {
@@ -425,17 +424,6 @@
         "@types/node": "*"
       }
     },
-    "node_modules/@types/lodash": {
-      "version": "4.14.190",
-      "license": "MIT"
-    },
-    "node_modules/@types/lodash.clonedeep": {
-      "version": "4.5.7",
-      "license": "MIT",
-      "dependencies": {
-        "@types/lodash": "*"
-      }
-    },
     "node_modules/@types/node": {
       "version": "20.3.1",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.3.1.tgz",
@@ -492,11 +480,6 @@
       "version": "0.16.2",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@types/uuid": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.2.tgz",
-      "integrity": "sha512-kNnC1GFBLuhImSnV7w4njQkUiJi0ZXUycu1rUaouPqiKlXkh77JKgdRnTAp1x5eBwcIwbtI+3otwzuIDEuDoxQ=="
     },
     "node_modules/abort-controller": {
       "version": "3.0.0",
@@ -709,9 +692,9 @@
       "license": "MIT"
     },
     "node_modules/core-js": {
-      "version": "3.31.0",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.31.0.tgz",
-      "integrity": "sha512-NIp2TQSGfR6ba5aalZD+ZQ1fSxGhDo/s1w0nx3RYzf2pnJxt7YynxFlFScP6eV7+GZsKO95NSjGxyJsU3DZgeQ==",
+      "version": "3.32.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.32.0.tgz",
+      "integrity": "sha512-rd4rYZNlF3WuoYuRIDEmbR/ga9CeuWX9U05umAvgrrZoHY4Z++cp/xwPQMvUpBB4Ag6J8KfD80G0zwCyaSxDww==",
       "hasInstallScript": true,
       "funding": {
         "type": "opencollective",
@@ -1320,11 +1303,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/lodash.clonedeep": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
-      "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ=="
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",

--- a/e2e/browser/test-app/package.json
+++ b/e2e/browser/test-app/package.json
@@ -9,8 +9,8 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@inrupt/solid-client": "^1.29.0",
-    "@inrupt/solid-client-authn-browser": "^1.16.0",
+    "@inrupt/solid-client": "^1.30.0",
+    "@inrupt/solid-client-authn-browser": "^1.17.1",
     "next": "^13.4.6",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -2217,18 +2217,22 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.28.1",
-      "license": "Apache-2.0",
+      "version": "1.37.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.37.0.tgz",
+      "integrity": "sha512-181WBLk4SRUyH1Q96VZl7BP6HcK0b7lbdeKisn3N/vnjitk+9HbdlFz/L5fey05vxaAhldIDnzo8KUoy8S3mmQ==",
       "peer": true,
       "dependencies": {
         "@types/node": "*",
-        "playwright-core": "1.28.1"
+        "playwright-core": "1.37.0"
       },
       "bin": {
         "playwright": "cli.js"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=16"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
       }
     },
     "node_modules/@puppeteer/browsers": {
@@ -10627,14 +10631,15 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.28.1",
-      "license": "Apache-2.0",
+      "version": "1.37.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.37.0.tgz",
+      "integrity": "sha512-1c46jhTH/myQw6sesrcuHVtLoSNfJv8Pfy9t3rs6subY7kARv0HRw5PpyfPYPpPtQvBOmgbE6K+qgYUpj81LAA==",
       "peer": true,
       "bin": {
-        "playwright": "cli.js"
+        "playwright-core": "cli.js"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=16"
       }
     },
     "node_modules/postcss": {
@@ -13199,7 +13204,7 @@
         "@inrupt/internal-test-env": "2.1.2"
       },
       "peerDependencies": {
-        "@playwright/test": "^1.28.1"
+        "@playwright/test": "^1.37.0"
       }
     },
     "packages/internal-playwright-testids": {
@@ -14774,11 +14779,14 @@
       "optional": true
     },
     "@playwright/test": {
-      "version": "1.28.1",
+      "version": "1.37.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.37.0.tgz",
+      "integrity": "sha512-181WBLk4SRUyH1Q96VZl7BP6HcK0b7lbdeKisn3N/vnjitk+9HbdlFz/L5fey05vxaAhldIDnzo8KUoy8S3mmQ==",
       "peer": true,
       "requires": {
         "@types/node": "*",
-        "playwright-core": "1.28.1"
+        "fsevents": "2.3.2",
+        "playwright-core": "1.37.0"
       }
     },
     "@puppeteer/browsers": {
@@ -20674,7 +20682,9 @@
       }
     },
     "playwright-core": {
-      "version": "1.28.1",
+      "version": "1.37.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.37.0.tgz",
+      "integrity": "sha512-1c46jhTH/myQw6sesrcuHVtLoSNfJv8Pfy9t3rs6subY7kARv0HRw5PpyfPYPpPtQvBOmgbE6K+qgYUpj81LAA==",
       "peer": true
     },
     "postcss": {

--- a/packages/internal-playwright-helpers/package.json
+++ b/packages/internal-playwright-helpers/package.json
@@ -24,6 +24,6 @@
     "@inrupt/internal-test-env": "2.1.2"
   },
   "peerDependencies": {
-    "@playwright/test": "^1.28.1"
+    "@playwright/test": "^1.37.0"
   }
 }

--- a/packages/internal-playwright-helpers/src/flows/auth.ts
+++ b/packages/internal-playwright-helpers/src/flows/auth.ts
@@ -58,10 +58,11 @@ export class AuthFlow {
     // Promise.all would do:
     await testPage.startLogin();
     await cognitoPage.login(this.userLogin, this.password);
+    const completeLoginConditions = [testPage.handleRedirect()];
     // TODO: handle allow === false
     if (options.allow) {
-      await openIdPage.allow();
+      completeLoginConditions.push(openIdPage.allow());
     }
-    await testPage.handleRedirect();
+    await Promise.all(completeLoginConditions);
   }
 }

--- a/packages/internal-playwright-helpers/src/flows/auth.ts
+++ b/packages/internal-playwright-helpers/src/flows/auth.ts
@@ -58,6 +58,10 @@ export class AuthFlow {
     // Promise.all would do:
     await testPage.startLogin();
     await cognitoPage.login(this.userLogin, this.password);
+    // Clicking on the consent screen from the broker will redirect to the
+    // test page, and trigger the token request. To prevent this being a
+    // race condition, waiting on this request should be done prior to
+    // giving consent.
     const completeLoginConditions = [testPage.handleRedirect()];
     // TODO: handle allow === false
     if (options.allow) {

--- a/packages/internal-playwright-helpers/src/pages/cognito.ts
+++ b/packages/internal-playwright-helpers/src/pages/cognito.ts
@@ -28,6 +28,8 @@ import type { Page } from "@playwright/test";
 export class CognitoPage {
   page: Page;
 
+  static URL = "https://auth.inrupt.com/login";
+
   constructor(page: Page) {
     this.page = page;
   }

--- a/packages/internal-playwright-helpers/src/pages/cognito.ts
+++ b/packages/internal-playwright-helpers/src/pages/cognito.ts
@@ -28,8 +28,6 @@ import type { Page } from "@playwright/test";
 export class CognitoPage {
   page: Page;
 
-  static URL = "https://auth.inrupt.com/login";
-
   constructor(page: Page) {
     this.page = page;
   }

--- a/packages/internal-playwright-helpers/src/pages/open-id.ts
+++ b/packages/internal-playwright-helpers/src/pages/open-id.ts
@@ -32,11 +32,14 @@ export class OpenIdPage {
   }
 
   async allow() {
+    // Class-based selector that will remain compatible with previous code
     const classBasedSelector = this.page.locator(".allow-button");
+    // Testid-based selector that will be compatible with newer releases
     const testidBasedSelector = this.page.getByTestId("prompt-allow");
+    // Once we no longer support ESS 2.1, we can remove the class-based selector and only use the testid-based one.
     await expect(classBasedSelector.or(testidBasedSelector)).toBeVisible();
     // Fallback selector to support class attributes, until testid supports is fully deployed.
-    const correctSelector = await classBasedSelector.isVisible() ? classBasedSelector : testidBasedSelector;
+    const correctSelector = await testidBasedSelector.isVisible() ? testidBasedSelector : classBasedSelector;
     await Promise.all([
       // It is important to call waitForNavigation before click to set up waiting.
       this.page.waitForURL("http://localhost*"),

--- a/packages/internal-playwright-helpers/src/pages/open-id.ts
+++ b/packages/internal-playwright-helpers/src/pages/open-id.ts
@@ -35,7 +35,7 @@ export class OpenIdPage {
     // Class-based selector that will remain compatible with previous code
     const classBasedSelector = this.page.locator(".allow-button");
     // Testid-based selector that will be compatible with newer releases
-    const testidBasedSelector = this.page.getByTestId("prompt-allow");
+    const testidBasedSelector = this.page.getByTestId("prompt-continue");
     // Once we no longer support ESS 2.1, we can remove the class-based selector and only use the testid-based one.
     await expect(classBasedSelector.or(testidBasedSelector)).toBeVisible();
     // Fallback selector to support class attributes, until testid supports is fully deployed.

--- a/packages/internal-playwright-helpers/src/pages/open-id.ts
+++ b/packages/internal-playwright-helpers/src/pages/open-id.ts
@@ -19,7 +19,7 @@
 // SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-import type { Page } from "@playwright/test";
+import { expect, type Page } from "@playwright/test";
 
 /**
  * The Solid-OIDC Broker exposed by ESS wrapped around an underlying OpenID Provider
@@ -32,11 +32,16 @@ export class OpenIdPage {
   }
 
   async allow() {
+    const classBasedSelector = this.page.locator(".allow-button");
+    const testidBasedSelector = this.page.getByTestId("prompt-allow");
+    await expect(classBasedSelector.or(testidBasedSelector)).toBeVisible();
+    // Fallback selector to support class attributes, until testid supports is fully deployed.
+    const correctSelector = await classBasedSelector.isVisible() ? classBasedSelector : testidBasedSelector;
     await Promise.all([
       // It is important to call waitForNavigation before click to set up waiting.
-      this.page.waitForNavigation(),
+      this.page.waitForURL("http://localhost*"),
       // Clicking the link will indirectly cause a navigation.
-      this.page.click("text=Allow"),
+      correctSelector.click(),
     ]);
   }
 

--- a/packages/internal-playwright-helpers/src/pages/open-id.ts
+++ b/packages/internal-playwright-helpers/src/pages/open-id.ts
@@ -39,7 +39,9 @@ export class OpenIdPage {
     // Once we no longer support ESS 2.1, we can remove the class-based selector and only use the testid-based one.
     await expect(classBasedSelector.or(testidBasedSelector)).toBeVisible();
     // Fallback selector to support class attributes, until testid supports is fully deployed.
-    const correctSelector = await testidBasedSelector.isVisible() ? testidBasedSelector : classBasedSelector;
+    const correctSelector = (await testidBasedSelector.isVisible())
+      ? testidBasedSelector
+      : classBasedSelector;
     await Promise.all([
       // It is important to call waitForNavigation before click to set up waiting.
       this.page.waitForURL("http://localhost*"),

--- a/packages/internal-playwright-helpers/src/pages/testPage.ts
+++ b/packages/internal-playwright-helpers/src/pages/testPage.ts
@@ -21,7 +21,6 @@
 
 import type { Page } from "@playwright/test";
 import { TESTID_SELECTORS } from "@inrupt/internal-playwright-testids";
-import { CognitoPage } from "./cognito";
 
 export class TestPage {
   page: Page;

--- a/packages/internal-playwright-helpers/src/pages/testPage.ts
+++ b/packages/internal-playwright-helpers/src/pages/testPage.ts
@@ -44,7 +44,7 @@ export class TestPage {
     );
     await Promise.all([
       // It is important to call waitForURL before click to set up waiting.
-      this.page.waitForURL(CognitoPage.URL),
+      this.page.waitForURL(/auth.*/),
       // Clicking the link will indirectly cause a navigation.
       this.page.click(TESTID_SELECTORS.LOGIN_BUTTON),
     ]);

--- a/packages/internal-playwright-helpers/src/pages/testPage.ts
+++ b/packages/internal-playwright-helpers/src/pages/testPage.ts
@@ -20,6 +20,7 @@
 //
 
 import type { Page } from "@playwright/test";
+import { CognitoPage } from "./cognito";
 import { TESTID_SELECTORS } from "@inrupt/internal-playwright-testids";
 
 export class TestPage {
@@ -43,7 +44,7 @@ export class TestPage {
     );
     await Promise.all([
       // It is important to call waitForURL before click to set up waiting.
-      this.page.waitForURL("*\\?response_type=code*"),
+      this.page.waitForURL(CognitoPage.URL),
       // Clicking the link will indirectly cause a navigation.
       this.page.click(TESTID_SELECTORS.LOGIN_BUTTON),
     ]);

--- a/packages/internal-playwright-helpers/src/pages/testPage.ts
+++ b/packages/internal-playwright-helpers/src/pages/testPage.ts
@@ -20,8 +20,8 @@
 //
 
 import type { Page } from "@playwright/test";
-import { CognitoPage } from "./cognito";
 import { TESTID_SELECTORS } from "@inrupt/internal-playwright-testids";
+import { CognitoPage } from "./cognito";
 
 export class TestPage {
   page: Page;

--- a/packages/internal-playwright-helpers/src/pages/testPage.ts
+++ b/packages/internal-playwright-helpers/src/pages/testPage.ts
@@ -42,8 +42,8 @@ export class TestPage {
       this.openidProvider
     );
     await Promise.all([
-      // It is important to call waitForNavigation before click to set up waiting.
-      this.page.waitForURL(this.openidProvider),
+      // It is important to call waitForURL before click to set up waiting.
+      this.page.waitForURL("*\\?response_type=code"),
       // Clicking the link will indirectly cause a navigation.
       this.page.click(TESTID_SELECTORS.LOGIN_BUTTON),
     ]);

--- a/packages/internal-playwright-helpers/src/pages/testPage.ts
+++ b/packages/internal-playwright-helpers/src/pages/testPage.ts
@@ -43,7 +43,7 @@ export class TestPage {
     );
     await Promise.all([
       // It is important to call waitForNavigation before click to set up waiting.
-      this.page.waitForNavigation(),
+      this.page.waitForURL(this.openidProvider),
       // Clicking the link will indirectly cause a navigation.
       this.page.click(TESTID_SELECTORS.LOGIN_BUTTON),
     ]);

--- a/packages/internal-playwright-helpers/src/pages/testPage.ts
+++ b/packages/internal-playwright-helpers/src/pages/testPage.ts
@@ -43,7 +43,7 @@ export class TestPage {
     );
     await Promise.all([
       // It is important to call waitForURL before click to set up waiting.
-      this.page.waitForURL("*\\?response_type=code"),
+      this.page.waitForURL("*\\?response_type=code*"),
       // Clicking the link will indirectly cause a navigation.
       this.page.click(TESTID_SELECTORS.LOGIN_BUTTON),
     ]);


### PR DESCRIPTION
This introduces two changes:
- Moving away from page.waitForNavigation(), which is deprecated
- Moving away from using a text-based selector. Instead, a class-based
  selector is used for legacy code, and a testid-based selector is
introduced for future releases, which will include the testid.

The class-based locator is used as a fallback, so that we remain compatible with current releases, and the testid-based one is used when possible against newer releases.