### PR TITLE
chore(release): publish 2.1.3

### DIFF
--- a/eslint-configs/eslint-config-base/package.json
+++ b/eslint-configs/eslint-config-base/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@inrupt/eslint-config-base",
   "description": "Shared eslint config for Javascript at @inrupt",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "publishConfig": {
     "access": "public"
   },

--- a/eslint-configs/eslint-config-lib/package.json
+++ b/eslint-configs/eslint-config-lib/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@inrupt/eslint-config-lib",
   "description": "Shared eslint config for Typescript Libraries used at @inrupt",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "publishConfig": {
     "access": "public"
   },

--- a/eslint-configs/eslint-config-react/package.json
+++ b/eslint-configs/eslint-config-react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@inrupt/eslint-config-react",
   "description": "Shared eslint config for React projects at @inrupt",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "publishConfig": {
     "access": "public"
   },

--- a/lerna.json
+++ b/lerna.json
@@ -1,4 +1,4 @@
 {
   "useNx": true,
-  "version": "2.1.2"
+  "version": "2.1.3"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
     },
     "eslint-configs/eslint-config-base": {
       "name": "@inrupt/eslint-config-base",
-      "version": "2.1.2",
+      "version": "2.1.3",
       "license": "MIT",
       "dependencies": {
         "eslint": ">=8.47.0",
@@ -51,7 +51,7 @@
     },
     "eslint-configs/eslint-config-lib": {
       "name": "@inrupt/eslint-config-lib",
-      "version": "2.1.2",
+      "version": "2.1.3",
       "license": "MIT",
       "dependencies": {
         "@inrupt/eslint-config-base": "file:../eslint-config-base",
@@ -62,7 +62,7 @@
     },
     "eslint-configs/eslint-config-react": {
       "name": "@inrupt/eslint-config-react",
-      "version": "2.1.2",
+      "version": "2.1.3",
       "license": "MIT",
       "dependencies": {
         "@babel/eslint-parser": "^7.22.10",
@@ -13942,16 +13942,16 @@
     },
     "packages/base-rollup-config": {
       "name": "@inrupt/base-rollup-config",
-      "version": "2.1.2",
+      "version": "2.1.3",
       "license": "MIT"
     },
     "packages/internal-playwright-helpers": {
       "name": "@inrupt/internal-playwright-helpers",
-      "version": "2.1.2",
+      "version": "2.1.3",
       "license": "MIT",
       "dependencies": {
-        "@inrupt/internal-playwright-testids": "2.1.2",
-        "@inrupt/internal-test-env": "2.1.2"
+        "@inrupt/internal-playwright-testids": "2.1.3",
+        "@inrupt/internal-test-env": "2.1.3"
       },
       "peerDependencies": {
         "@playwright/test": "^1.37.0"
@@ -13959,12 +13959,12 @@
     },
     "packages/internal-playwright-testids": {
       "name": "@inrupt/internal-playwright-testids",
-      "version": "2.1.2",
+      "version": "2.1.3",
       "license": "MIT"
     },
     "packages/internal-test-env": {
       "name": "@inrupt/internal-test-env",
-      "version": "2.1.2",
+      "version": "2.1.3",
       "license": "MIT",
       "dependencies": {
         "@inrupt/solid-client": "^1.30.0",
@@ -13977,7 +13977,7 @@
     },
     "packages/jest-jsdom-polyfills": {
       "name": "@inrupt/jest-jsdom-polyfills",
-      "version": "2.1.2",
+      "version": "2.1.3",
       "license": "MIT",
       "dependencies": {
         "@peculiar/webcrypto": "^1.4.0",
@@ -14530,8 +14530,8 @@
     "@inrupt/internal-playwright-helpers": {
       "version": "file:packages/internal-playwright-helpers",
       "requires": {
-        "@inrupt/internal-playwright-testids": "2.1.2",
-        "@inrupt/internal-test-env": "2.1.2"
+        "@inrupt/internal-playwright-testids": "2.1.3",
+        "@inrupt/internal-test-env": "2.1.3"
       }
     },
     "@inrupt/internal-playwright-testids": {

--- a/packages/base-rollup-config/package.json
+++ b/packages/base-rollup-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inrupt/base-rollup-config",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "description": "This package provides a shared rollup config for our packages",
   "main": "index.mjs",
   "module": "true",

--- a/packages/internal-playwright-helpers/package.json
+++ b/packages/internal-playwright-helpers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inrupt/internal-playwright-helpers",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "description": "This package provides page models for known common elements of the sdk testable UIs",
   "main": "dist/index.js",
   "module": "dist/index.es.js",
@@ -20,8 +20,8 @@
     }
   },
   "dependencies": {
-    "@inrupt/internal-playwright-testids": "2.1.2",
-    "@inrupt/internal-test-env": "2.1.2"
+    "@inrupt/internal-playwright-testids": "2.1.3",
+    "@inrupt/internal-test-env": "2.1.3"
   },
   "peerDependencies": {
     "@playwright/test": "^1.37.0"

--- a/packages/internal-playwright-testids/package.json
+++ b/packages/internal-playwright-testids/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inrupt/internal-playwright-testids",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "description": "Shared identifiers between browser-based tests and test app.",
   "main": "dist/index.js",
   "module": "dist/index.es.js",

--- a/packages/internal-test-env/package.json
+++ b/packages/internal-test-env/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inrupt/internal-test-env",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "description": "This package provides various test environment utilities needed for jest when using the Inrupt SDKs",
   "main": "dist/index.js",
   "module": "dist/index.es.js",

--- a/packages/jest-jsdom-polyfills/package.json
+++ b/packages/jest-jsdom-polyfills/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inrupt/jest-jsdom-polyfills",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "description": "This package provides various polyfills needed on jest/jsdom when using the Inrupt SDKs",
   "main": "index.js",
   "publishConfig": {


### PR DESCRIPTION
This release introduces https://github.com/inrupt/typescript-sdk-tools/commit/a60204d3d8cfb08e949d288df9cdc3cd1cb5a5a6, as well as dependency updates.