### PR TITLE
chore: create a reusable release workflow file

### DIFF
--- a/.github/workflows/reusable-release.yml
+++ b/.github/workflows/reusable-release.yml
@@ -1,0 +1,34 @@
+name: Reusable Release Workflow
+
+on:
+  workflow_call:
+    secrets:
+      NODE_AUTH_TOKEN:
+        required: true
+
+env:
+  CI: true
+jobs:
+  publish-npm:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Prepare for publication to npm
+        uses: actions/setup-node@v3
+        with:
+          node-version-file: ".nvmrc"
+          registry-url: "https://registry.npmjs.org"
+          cache: npm
+      - run: npm ci
+      - if: ${{ contains(github.ref_name, 'beta') }}
+        run: npm publish --access public --tag beta
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}
+      - if: ${{ contains(github.ref_name, 'alpha') }}
+        run: npm publish --access public --tag alpha
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}
+      - if: ${{ !contains(github.ref_name, 'alpha') && !contains(github.ref_name, 'beta') }}
+        run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}


### PR DESCRIPTION
Re-usable workflow to enable alpha/beta releases in our repos based on the [existing release workflow for universal fetch](https://github.com/inrupt/universal-fetch/blob/main/.github/workflows/release.yml).

Not dogfooding on this repo (yet) as the release configuration here significantly diverges from the release configuration for our SDK repos.

https://github.com/inrupt/typescript-sdk-tools/pull/447 is staged to release this work