### PR TITLE
chore(release): publish 2.5.0

### DIFF
--- a/eslint-configs/eslint-config-base/package.json
+++ b/eslint-configs/eslint-config-base/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@inrupt/eslint-config-base",
   "description": "Shared eslint config for Javascript at @inrupt",
-  "version": "2.4.1",
+  "version": "2.5.0",
   "publishConfig": {
     "access": "public"
   },

--- a/eslint-configs/eslint-config-lib/package.json
+++ b/eslint-configs/eslint-config-lib/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@inrupt/eslint-config-lib",
   "description": "Shared eslint config for Typescript Libraries used at @inrupt",
-  "version": "2.4.1",
+  "version": "2.5.0",
   "publishConfig": {
     "access": "public"
   },

--- a/eslint-configs/eslint-config-react/package.json
+++ b/eslint-configs/eslint-config-react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@inrupt/eslint-config-react",
   "description": "Shared eslint config for React projects at @inrupt",
-  "version": "2.4.1",
+  "version": "2.5.0",
   "publishConfig": {
     "access": "public"
   },

--- a/lerna.json
+++ b/lerna.json
@@ -1,4 +1,4 @@
 {
   "useNx": true,
-  "version": "2.4.1"
+  "version": "2.5.0"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
     },
     "eslint-configs/eslint-config-base": {
       "name": "@inrupt/eslint-config-base",
-      "version": "2.4.1",
+      "version": "2.5.0",
       "license": "MIT",
       "dependencies": {
         "eslint": ">=8.50.0",
@@ -51,7 +51,7 @@
     },
     "eslint-configs/eslint-config-lib": {
       "name": "@inrupt/eslint-config-lib",
-      "version": "2.4.1",
+      "version": "2.5.0",
       "license": "MIT",
       "dependencies": {
         "@inrupt/eslint-config-base": "file:../eslint-config-base",
@@ -62,7 +62,7 @@
     },
     "eslint-configs/eslint-config-react": {
       "name": "@inrupt/eslint-config-react",
-      "version": "2.4.1",
+      "version": "2.5.0",
       "license": "MIT",
       "dependencies": {
         "@babel/eslint-parser": "^7.22.15",
@@ -13613,7 +13613,7 @@
     },
     "packages/jest-jsdom-polyfills": {
       "name": "@inrupt/jest-jsdom-polyfills",
-      "version": "2.4.1",
+      "version": "2.5.0",
       "license": "MIT",
       "dependencies": {
         "@peculiar/webcrypto": "^1.4.0",

--- a/packages/jest-jsdom-polyfills/package.json
+++ b/packages/jest-jsdom-polyfills/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inrupt/jest-jsdom-polyfills",
-  "version": "2.4.1",
+  "version": "2.5.0",
   "description": "This package provides various polyfills needed on jest/jsdom when using the Inrupt SDKs",
   "main": "index.js",
   "publishConfig": {


### PR DESCRIPTION
To release the work in https://github.com/inrupt/typescript-sdk-tools/pull/446.

Do not merge until https://github.com/inrupt/typescript-sdk-tools/pull/446 is merged.