### PR TITLE
chore: note that packages require a `pre-publish` step

### DIFF
--- a/.github/workflows/reusable-release.yml
+++ b/.github/workflows/reusable-release.yml
@@ -1,3 +1,5 @@
+# This workflow assumes that that the package being published has a
+# pre-publish workflow step as we DO NOT call 'npm run build'
 name: Reusable Release Workflow
 
 on:


### PR DESCRIPTION
Resolving the comment in https://github.com/inrupt/typescript-sdk-tools/pull/446#discussion_r1363457651