### PR TITLE
Upgrade authn peer dep

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14110,13 +14110,15 @@
       "license": "MIT",
       "dependencies": {
         "@inrupt/solid-client": "^1.30.2",
-        "@inrupt/solid-client-authn-node": "^1.17.5",
         "@jeswr/css-auth-utils": "^1.4.0",
         "deepmerge-json": "^1.5.0",
         "dotenv": "^16.3.1"
       },
       "devDependencies": {
         "@inrupt/base-rollup-config": "3.0.0"
+      },
+      "peerDependencies": {
+        "@inrupt/solid-client-authn-node": "^1.17.5"
       }
     },
     "packages/jest-jsdom-polyfills": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -14110,15 +14110,70 @@
       "license": "MIT",
       "dependencies": {
         "@inrupt/solid-client": "^1.30.2",
+        "@inrupt/solid-client-authn-node": "^2.0.0",
         "@jeswr/css-auth-utils": "^1.4.0",
         "deepmerge-json": "^1.5.0",
         "dotenv": "^16.3.1"
       },
       "devDependencies": {
         "@inrupt/base-rollup-config": "3.0.0"
+      }
+    },
+    "packages/internal-test-env/node_modules/@inrupt/solid-client-authn-core": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@inrupt/solid-client-authn-core/-/solid-client-authn-core-2.0.0.tgz",
+      "integrity": "sha512-qM+E9I5u2DFlsfyoXossx8w0vKv8p+rXH98K9RUauJImpygQ3I3Ra6hSB2bwA1PdPQd5ttNg236oKe1sTT6Hqw==",
+      "dependencies": {
+        "events": "^3.3.0",
+        "jose": "^5.1.3",
+        "uuid": "^9.0.1"
       },
-      "peerDependencies": {
-        "@inrupt/solid-client-authn-node": "^1.17.5"
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0"
+      }
+    },
+    "packages/internal-test-env/node_modules/@inrupt/solid-client-authn-node": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@inrupt/solid-client-authn-node/-/solid-client-authn-node-2.0.0.tgz",
+      "integrity": "sha512-S1vGRodX0MSAKR3B6tm4qUvMhGv0sMcFjYyhVil7isoRI/7ei5QTpm+081RTWe6/cv4WI6UiHER3YIG15uwhhg==",
+      "dependencies": {
+        "@inrupt/solid-client-authn-core": "^2.0.0",
+        "jose": "^5.1.3",
+        "openid-client": "~5.6.1",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0"
+      }
+    },
+    "packages/internal-test-env/node_modules/jose": {
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-5.1.3.tgz",
+      "integrity": "sha512-GPExOkcMsCLBTi1YetY2LmkoY559fss0+0KVa6kOfb2YFe84nAM7Nm/XzuZozah4iHgmBGrCOHL5/cy670SBRw==",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "packages/internal-test-env/node_modules/openid-client": {
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/openid-client/-/openid-client-5.6.1.tgz",
+      "integrity": "sha512-PtrWsY+dXg6y8mtMPyL/namZSYVz8pjXz3yJiBNZsEdCnu9miHLB4ELVC85WvneMKo2Rg62Ay7NkuCpM0bgiLQ==",
+      "dependencies": {
+        "jose": "^4.15.1",
+        "lru-cache": "^6.0.0",
+        "object-hash": "^2.2.0",
+        "oidc-token-hash": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "packages/internal-test-env/node_modules/openid-client/node_modules/jose": {
+      "version": "4.15.4",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-4.15.4.tgz",
+      "integrity": "sha512-W+oqK4H+r5sITxfxpSU+MMdr/YSWGvgZMQDIsNoBDGGy4i7GBPTtvFKibQzW06n3U3TqHjhvBJsirShsEJ6eeQ==",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "packages/jest-jsdom-polyfills": {

--- a/packages/internal-test-env/package.json
+++ b/packages/internal-test-env/package.json
@@ -21,10 +21,12 @@
   },
   "dependencies": {
     "@inrupt/solid-client": "^1.30.2",
-    "@inrupt/solid-client-authn-node": "^1.17.5",
     "@jeswr/css-auth-utils": "^1.4.0",
     "deepmerge-json": "^1.5.0",
     "dotenv": "^16.3.1"
+  },
+  "peerDependencies": {
+    "@inrupt/solid-client-authn-node": "^1.17.5"
   },
   "devDependencies": {
     "@inrupt/base-rollup-config": "3.0.0"

--- a/packages/internal-test-env/package.json
+++ b/packages/internal-test-env/package.json
@@ -21,12 +21,10 @@
   },
   "dependencies": {
     "@inrupt/solid-client": "^1.30.2",
+    "@inrupt/solid-client-authn-node": "^2.0.0",
     "@jeswr/css-auth-utils": "^1.4.0",
     "deepmerge-json": "^1.5.0",
     "dotenv": "^16.3.1"
-  },
-  "peerDependencies": {
-    "@inrupt/solid-client-authn-node": "^1.17.5"
   },
   "devDependencies": {
     "@inrupt/base-rollup-config": "3.0.0"


### PR DESCRIPTION
I don't know if there is a better way to do this: upgrading the dev dependency of `@inrupt/solid-client-notifications` for instance breaks because of `Session` incompatibilities with this package.