### PR TITLE
Install latest NPM in audit workflow

### DIFF
--- a/.github/workflows/reusable-audit.yml
+++ b/.github/workflows/reusable-audit.yml
@@ -16,6 +16,9 @@ jobs:
           node-version: "20"
           registry-url: "https://registry.npmjs.org"
           cache: "npm"
+      # actions/setup-node doesn't necessarily install the latest NPM CLI
+      # version, and it has caused issues with signatures auditing for instance.
+      - run: npm install -g npm@latest
       # Install dependencies so license-checker actually checks them:
       - run: npm ci
       # We check the dependency licenses as part of the audit job, as a


### PR DESCRIPTION
The current workflow setup doesn't install the latest NPM version, and runs into issues that have been patched in more recent versions.

This enforces the latest npm is installed on the runner before performing audit operations.