### PR TITLE
Only check import resolution on typed linting

### DIFF
--- a/e2e/browser/test/e2e.playwright.ts
+++ b/e2e/browser/test/e2e.playwright.ts
@@ -18,8 +18,6 @@
 // SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-// We are using a typescript path but lint is not picking this up.
-// eslint-disable-next-line import/no-unresolved
 import { test, expect } from "@/packages/internal-playwright-helpers";
 
 test("creating and removing empty Containers", async ({ page, auth }) => {

--- a/e2e/browser/test/globalSetup.ts
+++ b/e2e/browser/test/globalSetup.ts
@@ -18,8 +18,6 @@
 // SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-// We are using a typescript path but lint is not picking this up.
-// eslint-disable-next-line import/no-unresolved
 import { setupEnv } from "@/packages/internal-test-env";
 
 async function globalSetup() {

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -21,7 +21,6 @@
 import inruptCfg from "@inrupt/eslint-config-base";
 import next from "@next/eslint-plugin-next";
 
-// eslint-disable-next-line import/no-unresolved
 import { defineConfig } from "eslint/config";
 
 export default defineConfig([

--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -82,7 +82,6 @@ export default defineConfig([
   },
   // TS config
   ...tseslint.configs.recommended,
-  importPlugin.flatConfigs.recommended,
   {
     languageOptions: {
       parserOptions: {
@@ -107,7 +106,10 @@ export default defineConfig([
       "@typescript-eslint/return-await": ["error", "in-try-catch"],
     },
     // Lint imports based on TS module resolution.
-    extends: [importPlugin.flatConfigs.typescript],
+    extends: [
+      importPlugin.flatConfigs.recommended,
+      importPlugin.flatConfigs.typescript
+    ],
     files: ["**/*.ts", "**/*.tsx"],
     // This avoids requiring a dedicated tsconfig.eslint.json file in every repo.
     ignores: [

--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -22,7 +22,6 @@ import js from "@eslint/js";
 import json from "@eslint/json";
 import markdown from "@eslint/markdown";
 
-// eslint-disable-next-line import/no-unresolved
 import { defineConfig, globalIgnores } from "eslint/config";
 import importPlugin from "eslint-plugin-import";
 import jest from "eslint-plugin-jest";
@@ -31,7 +30,6 @@ import prettier from "eslint-plugin-prettier/recommended";
 import react from "eslint-plugin-react";
 import hooks from "eslint-plugin-react-hooks";
 import globals from "globals";
-// eslint-disable-next-line import/no-unresolved
 import tseslint from "typescript-eslint";
 
 const typedLinting = {
@@ -82,44 +80,7 @@ export default defineConfig([
   },
   // TS config
   ...tseslint.configs.recommended,
-  {
-    languageOptions: {
-      parserOptions: {
-        projectService: true,
-        tsconfigRootDir: import.meta.dirname,
-      },
-    },
-    rules: {
-      "@typescript-eslint/no-floating-promises": "error",
-      "@typescript-eslint/no-empty-function": [
-        "error",
-        {
-          allow: ["arrowFunctions"],
-        },
-      ],
-      "@typescript-eslint/consistent-type-imports": [
-        "error",
-        {
-          prefer: "type-imports",
-        },
-      ],
-      "@typescript-eslint/return-await": ["error", "in-try-catch"],
-    },
-    // Lint imports based on TS module resolution.
-    extends: [
-      importPlugin.flatConfigs.recommended,
-      importPlugin.flatConfigs.typescript
-    ],
-    files: ["**/*.ts", "**/*.tsx"],
-    // This avoids requiring a dedicated tsconfig.eslint.json file in every repo.
-    ignores: [
-      "**/*.test.ts",
-      "**/*.mock*.ts",
-      "**/jest.setup.ts",
-      "**/e2e.playwright.ts",
-      "**/globalSetup.ts",
-    ],
-  },
+  typedLinting,
   // React config
   {
     plugins: {
@@ -220,6 +181,7 @@ export default defineConfig([
 
 export const ignoreTypedLinting = (paths) => {
   paths.forEach((path) => {
+    console.log("Ignoring " + path);
     typedLinting.ignores.push(path);
   });
 };

--- a/packages/jest-jsdom-polyfills/index.js
+++ b/packages/jest-jsdom-polyfills/index.js
@@ -18,7 +18,7 @@
 // SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-/* eslint-disable @typescript-eslint/no-require-imports,no-undef */
+/* eslint-disable @typescript-eslint/no-require-imports */
 
 // TextEncoder / TextDecoder APIs are used by Jose, but are not provided by
 // jsdom, all node versions supported provide these via the util module


### PR DESCRIPTION
Otherwise, the ESM import rules are applied, which are not applicable to TS files (extensions are ommitted in TS).