### PR TITLE
chore(release): publish 4.0.5

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,4 +1,4 @@
 {
   "useNx": true,
-  "version": "4.0.4"
+  "version": "4.0.5"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -15602,7 +15602,7 @@
     },
     "packages/base-rollup-config": {
       "name": "@inrupt/base-rollup-config",
-      "version": "4.0.4",
+      "version": "4.0.5",
       "license": "MIT",
       "dependencies": {
         "@rollup/plugin-typescript": "^12.1.4"
@@ -15610,7 +15610,7 @@
     },
     "packages/eslint-config": {
       "name": "@inrupt/eslint-config-base",
-      "version": "4.0.4",
+      "version": "4.0.5",
       "license": "MIT",
       "dependencies": {
         "@eslint/eslintrc": "^3.3.1",
@@ -15640,14 +15640,14 @@
     },
     "packages/internal-playwright-helpers": {
       "name": "@inrupt/internal-playwright-helpers",
-      "version": "4.0.4",
+      "version": "4.0.5",
       "license": "MIT",
       "dependencies": {
-        "@inrupt/internal-playwright-testids": "4.0.4",
-        "@inrupt/internal-test-env": "4.0.4"
+        "@inrupt/internal-playwright-testids": "4.0.5",
+        "@inrupt/internal-test-env": "4.0.5"
       },
       "devDependencies": {
-        "@inrupt/base-rollup-config": "4.0.4"
+        "@inrupt/base-rollup-config": "4.0.5"
       },
       "peerDependencies": {
         "@playwright/test": "^1.37.0"
@@ -15655,15 +15655,15 @@
     },
     "packages/internal-playwright-testids": {
       "name": "@inrupt/internal-playwright-testids",
-      "version": "4.0.4",
+      "version": "4.0.5",
       "license": "MIT",
       "devDependencies": {
-        "@inrupt/base-rollup-config": "4.0.4"
+        "@inrupt/base-rollup-config": "4.0.5"
       }
     },
     "packages/internal-test-env": {
       "name": "@inrupt/internal-test-env",
-      "version": "4.0.4",
+      "version": "4.0.5",
       "license": "MIT",
       "dependencies": {
         "@inrupt/solid-client": "^2.1.2",
@@ -15672,12 +15672,12 @@
         "dotenv": "^17.1.0"
       },
       "devDependencies": {
-        "@inrupt/base-rollup-config": "4.0.4"
+        "@inrupt/base-rollup-config": "4.0.5"
       }
     },
     "packages/jest-jsdom-polyfills": {
       "name": "@inrupt/jest-jsdom-polyfills",
-      "version": "4.0.4",
+      "version": "4.0.5",
       "license": "MIT",
       "dependencies": {
         "@peculiar/webcrypto": "^1.5.0",

--- a/packages/base-rollup-config/package.json
+++ b/packages/base-rollup-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inrupt/base-rollup-config",
-  "version": "4.0.4",
+  "version": "4.0.5",
   "description": "This package provides a shared rollup config for our packages",
   "main": "index.mjs",
   "module": "true",

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@inrupt/eslint-config-base",
   "description": "Shared eslint config for Javascript at @inrupt",
-  "version": "4.0.4",
+  "version": "4.0.5",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/internal-playwright-helpers/package.json
+++ b/packages/internal-playwright-helpers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inrupt/internal-playwright-helpers",
-  "version": "4.0.4",
+  "version": "4.0.5",
   "description": "This package provides page models for known common elements of the sdk testable UIs",
   "main": "dist/index.js",
   "module": "dist/index.es.js",
@@ -21,13 +21,13 @@
     }
   },
   "dependencies": {
-    "@inrupt/internal-playwright-testids": "4.0.4",
-    "@inrupt/internal-test-env": "4.0.4"
+    "@inrupt/internal-playwright-testids": "4.0.5",
+    "@inrupt/internal-test-env": "4.0.5"
   },
   "peerDependencies": {
     "@playwright/test": "^1.37.0"
   },
   "devDependencies": {
-    "@inrupt/base-rollup-config": "4.0.4"
+    "@inrupt/base-rollup-config": "4.0.5"
   }
 }

--- a/packages/internal-playwright-testids/package.json
+++ b/packages/internal-playwright-testids/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inrupt/internal-playwright-testids",
-  "version": "4.0.4",
+  "version": "4.0.5",
   "description": "Shared identifiers between browser-based tests and test app.",
   "main": "dist/index.js",
   "module": "dist/index.es.js",
@@ -20,6 +20,6 @@
     }
   },
   "devDependencies": {
-    "@inrupt/base-rollup-config": "4.0.4"
+    "@inrupt/base-rollup-config": "4.0.5"
   }
 }

--- a/packages/internal-test-env/package.json
+++ b/packages/internal-test-env/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inrupt/internal-test-env",
-  "version": "4.0.4",
+  "version": "4.0.5",
   "description": "This package provides various test environment utilities needed for jest when using the Inrupt SDKs",
   "main": "dist/index.js",
   "module": "dist/index.es.js",
@@ -26,6 +26,6 @@
     "dotenv": "^17.1.0"
   },
   "devDependencies": {
-    "@inrupt/base-rollup-config": "4.0.4"
+    "@inrupt/base-rollup-config": "4.0.5"
   }
 }

--- a/packages/jest-jsdom-polyfills/package.json
+++ b/packages/jest-jsdom-polyfills/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inrupt/jest-jsdom-polyfills",
-  "version": "4.0.4",
+  "version": "4.0.5",
   "description": "This package provides various polyfills needed on jest/jsdom when using the Inrupt SDKs",
   "main": "index.js",
   "publishConfig": {


### PR DESCRIPTION
Release the upgrade of the test helpers using the latest `solid-client-authn-node`, so that PRs such as https://github.com/inrupt/solid-client-errors-js/pull/438 no longer have internal conflicts.