### PR TITLE
Add missing types to export maps

### DIFF
--- a/packages/internal-playwright-testids/package.json
+++ b/packages/internal-playwright-testids/package.json
@@ -19,6 +19,7 @@
   "license": "MIT",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "require": "./dist/index.js",
       "import": "./dist/index.mjs"
     }

--- a/packages/internal-test-env/package.json
+++ b/packages/internal-test-env/package.json
@@ -19,6 +19,7 @@
   "license": "MIT",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "require": "./dist/index.js",
       "import": "./dist/index.mjs"
     }


### PR DESCRIPTION
This is required when TS modlue resolution mode is set to Bundler, which is the default starting in TS 6.