### PR TITLE
Remove NPM install step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,8 +22,6 @@ jobs:
           node-version: 22
           cache: npm
           registry-url: "https://registry.npmjs.org"
-      # Ensure npm 11.5.1 or later for trusted publishing
-      - run: npm install -g npm@latest
       - run: npm ci --workspaces
       # Running top-level ci should happen after workspaces level, running these
       # the other way around results in top-level dependencies (namely, lerna)


### PR DESCRIPTION
The setup node step already installs NPM, the forced install was only required when an older version of NPm could be picked up.