### PR TITLE
Add forcePublish flag to Lerna

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,4 +1,5 @@
 {
   "useNx": true,
-  "version": "4.1.1"
+  "version": "4.1.1",
+  "command": { "version": { "forcePublish": true } }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -16583,7 +16583,7 @@
     },
     "packages/base-rollup-config": {
       "name": "@inrupt/base-rollup-config",
-      "version": "4.1.0",
+      "version": "4.1.1",
       "license": "MIT",
       "dependencies": {
         "@rollup/plugin-typescript": "^12.3.0"
@@ -16683,7 +16683,7 @@
     },
     "packages/internal-playwright-helpers": {
       "name": "@inrupt/internal-playwright-helpers",
-      "version": "4.1.0",
+      "version": "4.1.1",
       "license": "MIT",
       "dependencies": {
         "@inrupt/internal-playwright-testids": "4.0.5",

--- a/packages/base-rollup-config/package.json
+++ b/packages/base-rollup-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inrupt/base-rollup-config",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "description": "This package provides a shared rollup config for our packages",
   "main": "index.mjs",
   "module": "true",

--- a/packages/internal-playwright-helpers/package.json
+++ b/packages/internal-playwright-helpers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inrupt/internal-playwright-helpers",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "description": "This package provides page models for known common elements of the sdk testable UIs",
   "main": "dist/index.js",
   "module": "dist/index.es.js",


### PR DESCRIPTION
This enforces version bumps even on monorepo packages that didn't have any changes since the last tag.