### PR TITLE
Revert "Remove NPM install step (#1677)"

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,8 @@ jobs:
           node-version: 22
           cache: npm
           registry-url: "https://registry.npmjs.org"
+      # Ensure npm 11.5.1 or later for trusted publishing
+      - run: npm install -g npm@latest
       - run: npm ci --workspaces
       # Running top-level ci should happen after workspaces level, running these
       # the other way around results in top-level dependencies (namely, lerna)


### PR DESCRIPTION
This reverts commit 898b4c5a2d1faaf59c1c95c75686a14282d495fe. Unlike what I understood yesterday, the issue is still present and the default NPM version in the setup-node GH action is still tool old for trusted publishing.