### PR TITLE
Fix Blob polyfill for jsdom

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5346,34 +5346,6 @@
         "win32"
       ]
     },
-    "node_modules/@web-std/blob": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@web-std/blob/-/blob-3.0.5.tgz",
-      "integrity": "sha512-Lm03qr0eT3PoLBuhkvFBLf0EFkAsNz/G/AYCzpOdi483aFaVX86b4iQs0OHhzHJfN5C15q17UtDbyABjlzM96A==",
-      "license": "MIT",
-      "dependencies": {
-        "@web-std/stream": "1.0.0",
-        "web-encoding": "1.1.5"
-      }
-    },
-    "node_modules/@web-std/file": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@web-std/file/-/file-3.0.3.tgz",
-      "integrity": "sha512-X7YYyvEERBbaDfJeC9lBKC5Q5lIEWYCP1SNftJNwNH/VbFhdHm+3neKOQP+kWEYJmosbDFq+NEUG7+XIvet/Jw==",
-      "license": "MIT",
-      "dependencies": {
-        "@web-std/blob": "^3.0.3"
-      }
-    },
-    "node_modules/@web-std/stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@web-std/stream/-/stream-1.0.0.tgz",
-      "integrity": "sha512-jyIbdVl+0ZJyKGTV0Ohb9E6UnxP+t7ZzX4Do3AHjZKxUXKMs9EmqnBDQgHF7bEw0EzbQygOjtt/7gvtmi//iCQ==",
-      "license": "MIT",
-      "dependencies": {
-        "web-streams-polyfill": "^3.1.1"
-      }
-    },
     "node_modules/@yarnpkg/lockfile": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz",
@@ -5391,13 +5363,6 @@
       "bin": {
         "js-yaml": "bin/js-yaml.js"
       }
-    },
-    "node_modules/@zxing/text-encoding": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/@zxing/text-encoding/-/text-encoding-0.9.0.tgz",
-      "integrity": "sha512-U/4aVJ2mxI0aDNI8Uq0wEhMgY+u4CNtEb0om3+y3+niDAsoTCOB33UF0sxpzqzdqXLqmvc+vZyAt4O8pPdfkwA==",
-      "license": "(Unlicense OR Apache-2.0)",
-      "optional": true
     },
     "node_modules/abbrev": {
       "version": "3.0.1",
@@ -9366,22 +9331,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 12"
-      }
-    },
-    "node_modules/is-arguments": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.2.0.tgz",
-      "integrity": "sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==",
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.2",
-        "has-tostringtag": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-array-buffer": {
@@ -16899,19 +16848,6 @@
         "punycode": "^2.1.0"
       }
     },
-    "node_modules/util": {
-      "version": "0.12.5",
-      "resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
-      "integrity": "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==",
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "is-arguments": "^1.0.4",
-        "is-generator-function": "^1.0.7",
-        "is-typed-array": "^1.1.3",
-        "which-typed-array": "^1.1.2"
-      }
-    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -16989,27 +16925,6 @@
       "license": "MIT",
       "dependencies": {
         "defaults": "^1.0.3"
-      }
-    },
-    "node_modules/web-encoding": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/web-encoding/-/web-encoding-1.1.5.tgz",
-      "integrity": "sha512-HYLeVCdJ0+lBYV2FvNZmv3HJ2Nt0QYXqZojk3d9FJOLkwnuhzM9tmamh8d7HPM8QqjKH8DeHkFTx+CFlWpZZDA==",
-      "license": "MIT",
-      "dependencies": {
-        "util": "^0.12.3"
-      },
-      "optionalDependencies": {
-        "@zxing/text-encoding": "0.9.0"
-      }
-    },
-    "node_modules/web-streams-polyfill": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
-      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 8"
       }
     },
     "node_modules/webcrypto-core": {
@@ -17646,8 +17561,6 @@
       "license": "MIT",
       "dependencies": {
         "@peculiar/webcrypto": "^1.7.1",
-        "@web-std/blob": "^3.0.5",
-        "@web-std/file": "^3.0.3",
         "undici": "^8.3.0"
       },
       "devDependencies": {

--- a/packages/jest-jsdom-polyfills/index.js
+++ b/packages/jest-jsdom-polyfills/index.js
@@ -67,16 +67,27 @@ if (
   globalThis.CryptoKey = WCryptoKey;
 }
 
-// Node.js doesn't support Blob or File, so we're polyfilling those with
-// https://github.com/web-std/io
-if (typeof globalThis.Blob === "undefined") {
-  const stdBlob = require("@web-std/blob");
-  globalThis.Blob = stdBlob.Blob;
+// jsdom ships its own Blob/File globals, but they are incomplete: their
+// prototypes only expose `slice`/`size`/`type` and are missing `text()`,
+// `arrayBuffer()` and `stream()`. Worse, undici's `Response.blob()`
+// constructs its result from `globalThis.Blob`, so the broken prototype
+// leaks into anything that reads a response body as a blob. We therefore
+// replace any Blob/File that lacks `text()` with Node's native, spec-compliant
+// implementations from `node:buffer` (available on all supported Node versions).
+const { Blob: NodeBlob, File: NodeFile } = require("node:buffer");
+
+if (
+  typeof globalThis.Blob === "undefined" ||
+  typeof globalThis.Blob.prototype.text !== "function"
+) {
+  globalThis.Blob = NodeBlob;
 }
 
-if (typeof globalThis.File === "undefined") {
-  const stdFile = require("@web-std/file");
-  globalThis.File = stdFile.File;
+if (
+  typeof globalThis.File === "undefined" ||
+  typeof globalThis.File.prototype.text !== "function"
+) {
+  globalThis.File = NodeFile;
 }
 
 // FIXME This is a temporary workaround for https://github.com/jsdom/jsdom/issues/1724#issuecomment-720727999

--- a/packages/jest-jsdom-polyfills/package.json
+++ b/packages/jest-jsdom-polyfills/package.json
@@ -26,8 +26,6 @@
   "homepage": "https://github.com/inrupt/typescript-sdk-tools#readme",
   "dependencies": {
     "@peculiar/webcrypto": "^1.7.1",
-    "@web-std/blob": "^3.0.5",
-    "@web-std/file": "^3.0.3",
     "undici": "^8.3.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Blob can be used from the node:buffer native package, now available in all supported versions.